### PR TITLE
feat: Added Support for Preset Namespaced Directories

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,5 +1,9 @@
 import chalk from "chalk";
-import { getConfig, getRuleSource } from "../utils/config";
+import {
+  getConfig,
+  getRuleSource,
+  getOriginalPresetPath,
+} from "../utils/config";
 import { detectRuleType } from "../utils/rule-detector";
 import { Config } from "../types";
 import {
@@ -162,6 +166,8 @@ export async function install(
       const ruleType = detectRuleType(source);
       // Get the base path of the preset file if this rule came from a preset
       const ruleBasePath = getRuleSource(config, name);
+      // Get the original preset path for namespacing
+      const originalPresetPath = getOriginalPresetPath(config, name);
 
       // Collect the rule based on its type
       try {
@@ -176,6 +182,11 @@ export async function install(
           default:
             errorMessages.push(`Unknown rule type: ${ruleType}`);
             continue;
+        }
+
+        // Add the preset path to the rule content for namespacing
+        if (originalPresetPath) {
+          ruleContent.presetPath = originalPresetPath;
         }
 
         addRuleToCollection(ruleCollection, ruleContent, config.ides);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -47,6 +47,7 @@ export interface RuleContent {
   content: string;
   metadata: RuleMetadata;
   sourcePath: string;
+  presetPath?: string;
 }
 
 // Collection of rules to be processed

--- a/src/utils/rule-writer.ts
+++ b/src/utils/rule-writer.ts
@@ -26,6 +26,23 @@ export function writeRulesToTargets(collection: RuleCollection): void {
 }
 
 /**
+ * Extract a normalized namespace from a preset path
+ * @param presetPath The original preset path
+ * @returns An array of path segments to use for namespacing
+ */
+function extractNamespaceFromPresetPath(presetPath: string): string[] {
+  // Special case: npm package names always use forward slashes, regardless of platform
+  if (presetPath.startsWith("@")) {
+    // For scoped packages like @scope/package/subdir, create nested directories
+    return presetPath.split("/");
+  }
+
+  // Handle both Unix and Windows style path separators
+  const parts = presetPath.split(/[/\\]/);
+  return parts.filter((part) => part.length > 0); // Filter out empty segments
+}
+
+/**
  * Write rules to Cursor's rules directory
  * @param rules The rules to write
  * @param cursorRulesDir The path to Cursor's rules directory
@@ -34,9 +51,24 @@ function writeCursorRules(rules: RuleContent[], cursorRulesDir: string): void {
   fs.emptyDirSync(cursorRulesDir);
 
   for (const rule of rules) {
-    const ruleFile =
-      path.join(cursorRulesDir, ...rule.name.split("/")) + ".mdc";
+    let rulePath;
+
+    // Parse rule name into path segments using platform-specific path separator
+    const ruleNameParts = rule.name.split(/[/\\]/).filter(Boolean);
+
+    if (rule.presetPath) {
+      // For rules from presets, create a namespaced directory structure
+      const namespace = extractNamespaceFromPresetPath(rule.presetPath);
+      // Path will be: cursorRulesDir/namespace/rule-name.mdc
+      rulePath = path.join(cursorRulesDir, ...namespace, ...ruleNameParts);
+    } else {
+      // For local rules, maintain the original flat structure
+      rulePath = path.join(cursorRulesDir, ...ruleNameParts);
+    }
+
+    const ruleFile = rulePath + ".mdc";
     fs.ensureDirSync(path.dirname(ruleFile));
+
     if (fs.existsSync(rule.sourcePath)) {
       fs.copyFileSync(rule.sourcePath, ruleFile);
     } else {
@@ -57,14 +89,37 @@ function writeWindsurfRulesFromCollection(
   fs.emptyDirSync(ruleDir);
 
   const ruleFiles = rules.map((rule) => {
-    const physicalRulePath =
-      path.join(ruleDir, ...rule.name.split("/")) + ".md";
+    let rulePath;
+
+    // Parse rule name into path segments using platform-specific path separator
+    const ruleNameParts = rule.name.split(/[/\\]/).filter(Boolean);
+
+    if (rule.presetPath) {
+      // For rules from presets, create a namespaced directory structure
+      const namespace = extractNamespaceFromPresetPath(rule.presetPath);
+      // Path will be: ruleDir/namespace/rule-name.md
+      rulePath = path.join(ruleDir, ...namespace, ...ruleNameParts);
+    } else {
+      // For local rules, maintain the original flat structure
+      rulePath = path.join(ruleDir, ...ruleNameParts);
+    }
+
+    const physicalRulePath = rulePath + ".md";
     fs.ensureDirSync(path.dirname(physicalRulePath));
     fs.writeFileSync(physicalRulePath, rule.content);
 
     const relativeRuleDir = path.basename(ruleDir); // Gets '.rules'
-    const windsurfPath =
-      path.join(relativeRuleDir, ...rule.name.split("/")) + ".md";
+
+    // For the Windsurf rules file, we need to maintain the same structure
+    let windsurfPath;
+    if (rule.presetPath) {
+      const namespace = extractNamespaceFromPresetPath(rule.presetPath);
+      windsurfPath =
+        path.join(relativeRuleDir, ...namespace, ...ruleNameParts) + ".md";
+    } else {
+      windsurfPath = path.join(relativeRuleDir, ...ruleNameParts) + ".md";
+    }
+
     // Normalize to POSIX style for cross-platform compatibility in .windsurfrules
     const windsurfPathPosix = windsurfPath.replace(/\\/g, "/");
 
@@ -74,6 +129,7 @@ function writeWindsurfRulesFromCollection(
       metadata: rule.metadata,
     };
   });
+
   const windsurfRulesContent = generateWindsurfRulesContent(ruleFiles);
   writeWindsurfRules(windsurfRulesContent);
 }

--- a/tests/e2e/presets.test.ts
+++ b/tests/e2e/presets.test.ts
@@ -1,6 +1,4 @@
 import path from "path";
-import * as fs from "fs";
-import { testDir } from "./helpers";
 import {
   setupFromFixture,
   runCommand,
@@ -20,19 +18,47 @@ describe("Presets with fixtures", () => {
     expect(code).toBe(0);
 
     expect(
-      fileExists(path.join(".cursor", "rules", "aicm", "typescript-rule.mdc")),
+      fileExists(
+        path.join(
+          ".cursor",
+          "rules",
+          "aicm",
+          "company-preset-full.json",
+          "typescript-rule.mdc",
+        ),
+      ),
     ).toBe(true);
     expect(
-      fileExists(path.join(".cursor", "rules", "aicm", "react-rule.mdc")),
+      fileExists(
+        path.join(
+          ".cursor",
+          "rules",
+          "aicm",
+          "company-preset-full.json",
+          "react-rule.mdc",
+        ),
+      ),
     ).toBe(true);
 
     const typescriptRuleContent = readTestFile(
-      path.join(".cursor", "rules", "aicm", "typescript-rule.mdc"),
+      path.join(
+        ".cursor",
+        "rules",
+        "aicm",
+        "company-preset-full.json",
+        "typescript-rule.mdc",
+      ),
     );
     expect(typescriptRuleContent).toContain("TypeScript Best Practices");
 
     const reactRuleContent = readTestFile(
-      path.join(".cursor", "rules", "aicm", "react-rule.mdc"),
+      path.join(
+        ".cursor",
+        "rules",
+        "aicm",
+        "company-preset-full.json",
+        "react-rule.mdc",
+      ),
     );
     expect(reactRuleContent).toContain("React Best Practices");
   });
@@ -45,14 +71,28 @@ describe("Presets with fixtures", () => {
     expect(code).toBe(0);
 
     expect(
-      fileExists(path.join(".cursor", "rules", "aicm", "preset-rule.mdc")),
+      fileExists(
+        path.join(
+          ".cursor",
+          "rules",
+          "aicm",
+          "company-preset.json",
+          "preset-rule.mdc",
+        ),
+      ),
     ).toBe(true);
     expect(
       fileExists(path.join(".cursor", "rules", "aicm", "local-rule.mdc")),
     ).toBe(true);
 
     const presetRuleContent = readTestFile(
-      path.join(".cursor", "rules", "aicm", "preset-rule.mdc"),
+      path.join(
+        ".cursor",
+        "rules",
+        "aicm",
+        "company-preset.json",
+        "preset-rule.mdc",
+      ),
     );
     expect(presetRuleContent).toContain("Preset Rule");
 
@@ -80,11 +120,27 @@ describe("Presets with fixtures", () => {
     expect(code).toBe(0);
 
     expect(
-      fileExists(path.join(".cursor", "rules", "aicm", "npm-rule.mdc")),
+      fileExists(
+        path.join(
+          ".cursor",
+          "rules",
+          "aicm",
+          "@company",
+          "ai-rules",
+          "npm-rule.mdc",
+        ),
+      ),
     ).toBe(true);
 
     const npmRuleContent = readTestFile(
-      path.join(".cursor", "rules", "aicm", "npm-rule.mdc"),
+      path.join(
+        ".cursor",
+        "rules",
+        "aicm",
+        "@company",
+        "ai-rules",
+        "npm-rule.mdc",
+      ),
     );
     expect(npmRuleContent).toContain("NPM Package Rule");
   });
@@ -96,10 +152,26 @@ describe("Presets with fixtures", () => {
 
     expect(code).toBe(0);
     expect(
-      fileExists(path.join(".cursor", "rules", "aicm", "npm-rule.mdc")),
+      fileExists(
+        path.join(
+          ".cursor",
+          "rules",
+          "aicm",
+          "@company",
+          "ai-rules",
+          "npm-rule.mdc",
+        ),
+      ),
     ).toBe(true);
     const npmRuleContent = readTestFile(
-      path.join(".cursor", "rules", "aicm", "npm-rule.mdc"),
+      path.join(
+        ".cursor",
+        "rules",
+        "aicm",
+        "@company",
+        "ai-rules",
+        "npm-rule.mdc",
+      ),
     );
     expect(npmRuleContent).toContain("NPM Package Rule");
   });
@@ -159,16 +231,11 @@ describe("Presets with fixtures", () => {
   });
 
   test("should cancel a rule and mcpServer from a preset when set to false", async () => {
-    // Setup fixture, then modify aicm.json to cancel rule and mcpServer
+    // Use a fixture with pre-canceled rules and mcpServers
     await setupFromFixture(
-      "presets-npm-override",
+      "presets-cancel-rules",
       expect.getState().currentTestName,
     );
-    const configPath = path.join(testDir, "aicm.json");
-    const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
-    config.rules["npm-rule"] = false;
-    config.mcpServers["preset-mcp"] = false;
-    fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
 
     const { code } = await runCommand("install --ci");
     expect(code).toBe(0);
@@ -183,5 +250,45 @@ describe("Presets with fixtures", () => {
     expect(fileExists(mcpPath)).toBe(true);
     const mcpConfig = JSON.parse(readTestFile(mcpPath));
     expect(mcpConfig.mcpServers["preset-mcp"]).toBeUndefined();
+  });
+
+  test("should support namespaced directories for preset rules", async () => {
+    await setupFromFixture(
+      "presets-namespaced-dirs",
+      expect.getState().currentTestName,
+    );
+
+    const { code } = await runCommand("install --ci");
+
+    expect(code).toBe(0);
+
+    // Check that the rules are installed in their namespaced directories
+    const rootRulePath = path.join(
+      ".cursor",
+      "rules",
+      "aicm",
+      "@aicm",
+      "test-preset",
+      "root-rule.mdc",
+    );
+    const subdirRulePath = path.join(
+      ".cursor",
+      "rules",
+      "aicm",
+      "@aicm",
+      "test-preset",
+      "subdir",
+      "subdir-rule.mdc",
+    );
+
+    expect(fileExists(rootRulePath)).toBe(true);
+    expect(fileExists(subdirRulePath)).toBe(true);
+
+    // Check the content
+    const rootRuleContent = readTestFile(rootRulePath);
+    expect(rootRuleContent).toContain("Root Rule Content");
+
+    const subdirRuleContent = readTestFile(subdirRulePath);
+    expect(subdirRuleContent).toContain("Subdir Rule Content");
   });
 });

--- a/tests/e2e/presets.test.ts
+++ b/tests/e2e/presets.test.ts
@@ -262,7 +262,6 @@ describe("Presets with fixtures", () => {
 
     expect(code).toBe(0);
 
-    // Check that the rules are installed in their namespaced directories
     const rootRulePath = path.join(
       ".cursor",
       "rules",

--- a/tests/e2e/readme-example.test.ts
+++ b/tests/e2e/readme-example.test.ts
@@ -9,7 +9,6 @@ import path from "path";
 describe("README demo example", () => {
   test("should install rules from preset as shown in the README", async () => {
     await setupFromFixture("readme-demo", expect.getState().currentTestName);
-
     const npmResult = await runNpmInstall("pirate-coding");
     expect(npmResult.code).toBe(0);
     const { stdout, code } = await runCommand("install --ci");
@@ -17,7 +16,9 @@ describe("README demo example", () => {
     expect(code).toBe(0);
     expect(stdout).toContain("Rules installation completed");
     expect(
-      fileExists(path.join(".cursor", "rules", "aicm", "pirate-coding.mdc")),
+      fileExists(
+        path.join(".cursor", "rules", "aicm", "pirate-coding", "rule.mdc"),
+      ),
     ).toBe(true);
     expect(fileExists(path.join(".cursor", "mcp.json"))).toBe(true);
   });

--- a/tests/fixtures/presets-cancel-rules/aicm.json
+++ b/tests/fixtures/presets-cancel-rules/aicm.json
@@ -1,0 +1,10 @@
+{
+  "ides": ["cursor"],
+  "presets": ["./preset.json"],
+  "rules": {
+    "npm-rule": false
+  },
+  "mcpServers": {
+    "preset-mcp": false
+  }
+}

--- a/tests/fixtures/presets-cancel-rules/preset.json
+++ b/tests/fixtures/presets-cancel-rules/preset.json
@@ -1,0 +1,11 @@
+{
+  "rules": {
+    "npm-rule": "./rules/preset-rule.mdc"
+  },
+  "mcpServers": {
+    "preset-mcp": {
+      "command": "./scripts/preset-mcp.sh",
+      "env": { "MCP_TOKEN": "preset" }
+    }
+  }
+}

--- a/tests/fixtures/presets-cancel-rules/rules/preset-rule.mdc
+++ b/tests/fixtures/presets-cancel-rules/rules/preset-rule.mdc
@@ -1,0 +1,5 @@
+---
+description:
+globs:
+alwaysApply: false
+---

--- a/tests/fixtures/presets-namespaced-dirs/aicm.json
+++ b/tests/fixtures/presets-namespaced-dirs/aicm.json
@@ -1,0 +1,4 @@
+{
+  "ides": ["cursor"],
+  "presets": ["@aicm/test-preset", "@aicm/test-preset/subdir"]
+}

--- a/tests/fixtures/presets-namespaced-dirs/node_modules/@aicm/test-preset/aicm.json
+++ b/tests/fixtures/presets-namespaced-dirs/node_modules/@aicm/test-preset/aicm.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "root-rule": "./rules/root-rule.mdc"
+  }
+} 

--- a/tests/fixtures/presets-namespaced-dirs/node_modules/@aicm/test-preset/rules/root-rule.mdc
+++ b/tests/fixtures/presets-namespaced-dirs/node_modules/@aicm/test-preset/rules/root-rule.mdc
@@ -1,0 +1,5 @@
+---
+description:
+globs:
+alwaysApply: false
+---

--- a/tests/fixtures/presets-namespaced-dirs/node_modules/@aicm/test-preset/rules/root-rule.mdc
+++ b/tests/fixtures/presets-namespaced-dirs/node_modules/@aicm/test-preset/rules/root-rule.mdc
@@ -1,7 +1,8 @@
 ---
-description:
-globs:
+description: 
+globs: 
 alwaysApply: true
 ---
+# Root Rule
 
-Root preset rule
+Root Rule Content

--- a/tests/fixtures/presets-namespaced-dirs/node_modules/@aicm/test-preset/rules/root-rule.mdc
+++ b/tests/fixtures/presets-namespaced-dirs/node_modules/@aicm/test-preset/rules/root-rule.mdc
@@ -1,5 +1,7 @@
 ---
 description:
 globs:
-alwaysApply: false
+alwaysApply: true
 ---
+
+Root preset rule

--- a/tests/fixtures/presets-namespaced-dirs/node_modules/@aicm/test-preset/subdir/aicm.json
+++ b/tests/fixtures/presets-namespaced-dirs/node_modules/@aicm/test-preset/subdir/aicm.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "subdir-rule": "./rules/subdir-rule.mdc"
+  }
+} 

--- a/tests/fixtures/presets-namespaced-dirs/node_modules/@aicm/test-preset/subdir/rules/subdir-rule.mdc
+++ b/tests/fixtures/presets-namespaced-dirs/node_modules/@aicm/test-preset/subdir/rules/subdir-rule.mdc
@@ -1,0 +1,5 @@
+---
+description:
+globs:
+alwaysApply: false
+---

--- a/tests/fixtures/presets-namespaced-dirs/node_modules/@aicm/test-preset/subdir/rules/subdir-rule.mdc
+++ b/tests/fixtures/presets-namespaced-dirs/node_modules/@aicm/test-preset/subdir/rules/subdir-rule.mdc
@@ -3,3 +3,5 @@ description:
 globs:
 alwaysApply: false
 ---
+
+Subdir Rule Content

--- a/tests/fixtures/windsurf-append-markers/aicm.json
+++ b/tests/fixtures/windsurf-append-markers/aicm.json
@@ -1,0 +1,6 @@
+{
+  "ides": ["windsurf"],
+  "rules": {
+    "no-marker-rule": "./rules/no-marker-rule.mdc"
+  }
+}


### PR DESCRIPTION
This PR implements namespaced directory organization for rules from presets, improving organization when multiple presets are installed. It also prevents collisions in case 2 presets used the same name for a rule.

**Before:**
```
.cursor/rules/
├── rule1.mdc
├── rule2.mdc
└── rule3.mdc
```

**After:**
```
.cursor/rules/
├── preset1/
│   ├── rule1.mdc
│   └── rule2.mdc
└── preset2/
    └── rule3.mdc
```