### PR TITLE
Improve e2e infra by setting each test file in a directory

### DIFF
--- a/tests/E2E_TESTS.md
+++ b/tests/E2E_TESTS.md
@@ -13,7 +13,7 @@ import { setupFromFixture, runCommand } from "./helpers";
 describe("my test", () => {
   test("should do something", async () => {
     // Setup the test directory using a fixture
-    await setupFromFixture("fixture-name", expect.getState().currentTestName);
+    await setupFromFixture("fixture-name");
 
     // Run your test...
     const { stdout, stderr, code } = await runCommand("some-command");
@@ -55,7 +55,7 @@ tests/fixtures/e2e/list-with-multiple-rules/
    - Each fixture should be self-contained and independent
 
 3. **Using Fixtures in Tests**
-   - Use `setupFromFixture(fixtureName, testName)` to initialize test state
+   - Use `setupFromFixture(fixtureName)` to initialize test state
    - Verify fixture content exists before running tests
    - For empty starting states, use the `init-empty` fixture
 
@@ -94,7 +94,7 @@ Modifying files after fixture setup should be limited to specific test requireme
 ```typescript
 // Only modify files when testing file modification functionality
 test("should handle configuration updates", async () => {
-  await setupFromFixture("config-basic", expect.getState().currentTestName);
+  await setupFromFixture("config-basic");
 
   // Modifying only when testing specific behavior
   // Use helpers like readTestFile and carefully document the purpose
@@ -115,10 +115,7 @@ test("should handle configuration updates", async () => {
 // GOOD PRACTICE
 test("should test specific functionality", async () => {
   // Start with a complete fixture containing all needed files
-  await setupFromFixture(
-    "my-complete-fixture",
-    expect.getState().currentTestName,
-  );
+  await setupFromFixture("my-complete-fixture");
 
   // Run command
   const { code } = await runCommand("install --ci");

--- a/tests/e2e/api.test.ts
+++ b/tests/e2e/api.test.ts
@@ -15,10 +15,7 @@ describe("aicm Node.js API", () => {
   });
 
   test("should install rules using the API with default options", async () => {
-    await setupFromFixture(
-      "install-from-config",
-      expect.getState().currentTestName,
-    );
+    await setupFromFixture("install-from-config");
 
     const result = await install({
       cwd: testDir,
@@ -32,10 +29,7 @@ describe("aicm Node.js API", () => {
   });
 
   test("should install rules using the API with custom config", async () => {
-    await setupFromFixture(
-      "api-test-custom-config",
-      expect.getState().currentTestName,
-    );
+    await setupFromFixture("api-test-custom-config");
 
     const rulePath = path.join(testDir, "rules", "test-rule.mdc");
     expect(fs.existsSync(rulePath)).toBe(true);
@@ -76,10 +70,7 @@ describe("aicm Node.js API", () => {
   });
 
   test("should use cursor as default IDE when ides field is not specified", async () => {
-    await setupFromFixture(
-      "api-test-default-ide",
-      expect.getState().currentTestName,
-    );
+    await setupFromFixture("api-test-default-ide");
 
     const result = await install({
       cwd: testDir,
@@ -103,7 +94,7 @@ describe("aicm Node.js API", () => {
   });
 
   test("should handle config with no rules correctly", async () => {
-    await setupTestDir(expect.getState().currentTestName);
+    await setupTestDir();
 
     const config: Config = {
       ides: ["cursor"],
@@ -121,10 +112,7 @@ describe("aicm Node.js API", () => {
   });
 
   test("should handle custom working directory", async () => {
-    await setupFromFixture(
-      "install-from-config",
-      expect.getState().currentTestName,
-    );
+    await setupFromFixture("install-from-config");
 
     const subDir = path.join(testDir, "subdir");
     fs.mkdirSync(subDir, { recursive: true });

--- a/tests/e2e/ci.test.ts
+++ b/tests/e2e/ci.test.ts
@@ -45,10 +45,7 @@ describe("aicm install CI behavior", () => {
 
   describe("CLI Behavior", () => {
     test("should skip install on CI by default", async () => {
-      await setupFromFixture(
-        "install-basic",
-        expect.getState().currentTestName,
-      );
+      await setupFromFixture("install-basic");
 
       const { stdout, code } = await runCommandWithCI("install");
 
@@ -58,10 +55,7 @@ describe("aicm install CI behavior", () => {
     });
 
     test("should install when --ci flag is used", async () => {
-      await setupFromFixture(
-        "install-basic",
-        expect.getState().currentTestName,
-      );
+      await setupFromFixture("install-basic");
 
       const { stdout, code } = await runCommandWithCI("install --ci");
 
@@ -71,10 +65,7 @@ describe("aicm install CI behavior", () => {
     });
 
     test("should install when installOnCI is true in config", async () => {
-      await setupFromFixture(
-        "install-basic-ci",
-        expect.getState().currentTestName,
-      );
+      await setupFromFixture("install-basic-ci");
 
       const { stdout, code } = await runCommandWithCI("install");
 
@@ -84,10 +75,7 @@ describe("aicm install CI behavior", () => {
     });
 
     test("should proceed with install when NOT in CI (regardless of flags/config)", async () => {
-      await setupFromFixture(
-        "install-basic",
-        expect.getState().currentTestName,
-      );
+      await setupFromFixture("install-basic");
       // Ensure we're NOT using CI=true for this test - we'll explicitly set it to false
 
       // Scenario 1: No flag, no special config
@@ -118,10 +106,7 @@ describe("aicm install CI behavior", () => {
 
   describe("Node API Behavior", () => {
     test("should skip install on CI by default", async () => {
-      await setupFromFixture(
-        "install-basic",
-        expect.getState().currentTestName,
-      );
+      await setupFromFixture("install-basic");
 
       const result = await runApiWithCI(() => installApi({ cwd: testDir }));
 
@@ -131,10 +116,7 @@ describe("aicm install CI behavior", () => {
     });
 
     test("should install on CI when installOnCI option is true", async () => {
-      await setupFromFixture(
-        "install-basic",
-        expect.getState().currentTestName,
-      );
+      await setupFromFixture("install-basic");
 
       const result = await runApiWithCI(() =>
         installApi({ cwd: testDir, installOnCI: true }),
@@ -146,10 +128,7 @@ describe("aicm install CI behavior", () => {
     });
 
     test("should install on CI when installOnCI is true in config", async () => {
-      await setupFromFixture(
-        "install-basic-ci",
-        expect.getState().currentTestName,
-      );
+      await setupFromFixture("install-basic-ci");
 
       const result = await runApiWithCI(() => installApi({ cwd: testDir }));
 
@@ -159,10 +138,7 @@ describe("aicm install CI behavior", () => {
     });
 
     test("should install when NOT in CI regardless of options", async () => {
-      await setupFromFixture(
-        "install-basic",
-        expect.getState().currentTestName,
-      );
+      await setupFromFixture("install-basic");
 
       // Save original CI value
       const originalCI = process.env.CI;

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -50,7 +50,12 @@ function sanitizeFilename(name: string): string {
  * @param testFilename The name of the test file
  * @param testName The name of the individual test
  */
-export async function setupTestDir(testName?: string): Promise<string> {
+export async function setupTestDir(): Promise<string> {
+  const testPath = expect.getState().testPath!;
+  const testFileName = path.basename(testPath, ".test.ts");
+  const testName = expect.getState().currentTestName;
+
+  // Sanitize test name
   // If no test identifiers provided, use the root tmp-test directory
   if (!testName) {
     // Create the root test directory if it doesn't exist
@@ -60,13 +65,12 @@ export async function setupTestDir(testName?: string): Promise<string> {
     return testDir;
   }
 
-  // Sanitize test name
   const sanitizedTestName = testName
     ? sanitizeFilename(testName)
     : "unknown-test";
 
   // Create a directory path with just the command name and sanitized test name
-  const newTestDir = path.join(testRootDir, sanitizedTestName);
+  const newTestDir = path.join(testRootDir, testFileName, sanitizedTestName);
 
   // Remove any existing test directory
   await rimraf(newTestDir);
@@ -156,16 +160,11 @@ export function getDirectoryStructure(dir: string = ""): string[] {
 /**
  * Setup a test directory using a fixture directory
  * @param fixtureName The name of the fixture directory to use
- * @param testName Optional test name for the directory
  */
-export async function setupFromFixture(
-  fixtureName: string,
-  testName?: string,
-): Promise<string> {
+export async function setupFromFixture(fixtureName: string): Promise<string> {
   // First setup a clean test directory
-  await setupTestDir(testName);
+  await setupTestDir();
 
-  // Copy the entire fixture directory to the test directory
   const fixtureDir = path.join(e2eFixturesDir, fixtureName);
 
   if (!fs.existsSync(fixtureDir)) {

--- a/tests/e2e/init.test.ts
+++ b/tests/e2e/init.test.ts
@@ -10,7 +10,7 @@ import { testDir } from "./helpers";
 
 describe("aicm init command with fixtures", () => {
   test("should create default config file", async () => {
-    await setupFromFixture("init-empty", expect.getState().currentTestName);
+    await setupFromFixture("init-empty");
 
     await runCommand("init");
 
@@ -22,7 +22,7 @@ describe("aicm init command with fixtures", () => {
   });
 
   test("should not overwrite existing config", async () => {
-    await setupFromFixture("init-empty", expect.getState().currentTestName);
+    await setupFromFixture("init-empty");
 
     const customConfig = { ides: ["custom"], rules: {} };
     fs.writeJsonSync(path.join(testDir, "aicm.json"), customConfig);

--- a/tests/e2e/install.test.ts
+++ b/tests/e2e/install.test.ts
@@ -8,10 +8,7 @@ import {
 
 describe("aicm install command with fixtures", () => {
   test("should show error when no rule is specified", async () => {
-    await setupFromFixture(
-      "install-no-rules",
-      expect.getState().currentTestName,
-    );
+    await setupFromFixture("install-no-rules");
 
     const { stderr } = await runCommand("install --ci");
 
@@ -19,10 +16,7 @@ describe("aicm install command with fixtures", () => {
   });
 
   test("should show error when config doesn't exist", async () => {
-    await setupFromFixture(
-      "install-no-config",
-      expect.getState().currentTestName,
-    );
+    await setupFromFixture("install-no-config");
 
     const { stderr, code } = await runCommand("install --ci");
 
@@ -31,10 +25,7 @@ describe("aicm install command with fixtures", () => {
   });
 
   test("should install rules from config", async () => {
-    await setupFromFixture(
-      "install-from-config",
-      expect.getState().currentTestName,
-    );
+    await setupFromFixture("install-from-config");
 
     const { code } = await runCommand("install --ci");
 
@@ -64,10 +55,7 @@ describe("aicm install command with fixtures", () => {
   });
 
   test("should handle errors with missing rule files", async () => {
-    await setupFromFixture(
-      "install-missing-rules",
-      expect.getState().currentTestName,
-    );
+    await setupFromFixture("install-missing-rules");
 
     const { stderr, code } = await runCommand("install --ci");
 
@@ -78,10 +66,7 @@ describe("aicm install command with fixtures", () => {
   });
 
   test("should install rules into specified subdirectory when rule key includes a directory", async () => {
-    await setupFromFixture(
-      "install-rule-in-subdir",
-      expect.getState().currentTestName,
-    );
+    await setupFromFixture("install-rule-in-subdir");
 
     const { code } = await runCommand("install --ci");
 
@@ -101,10 +86,7 @@ describe("aicm install command with fixtures", () => {
   });
 
   test("should clean stale Cursor rules on installation", async () => {
-    await setupFromFixture(
-      "install-cursor-cleanup",
-      expect.getState().currentTestName,
-    );
+    await setupFromFixture("install-cursor-cleanup");
 
     const staleRulePath = path.join(
       ".cursor",
@@ -131,10 +113,7 @@ describe("aicm install command with fixtures", () => {
   });
 
   test("should clean stale Windsurf rules and .aicm directory before installation", async () => {
-    await setupFromFixture(
-      "install-windsurf-cleanup",
-      expect.getState().currentTestName,
-    );
+    await setupFromFixture("install-windsurf-cleanup");
 
     expect(fileExists(path.join(".aicm", "stale-windsurf-rule.md"))).toBe(true);
     const oldFreshContent = readTestFile(

--- a/tests/e2e/list.test.ts
+++ b/tests/e2e/list.test.ts
@@ -2,10 +2,7 @@ import { setupFromFixture, runCommand } from "./helpers";
 
 describe("aicm list command with fixtures", () => {
   test("should list all rules in the config", async () => {
-    await setupFromFixture(
-      "list-with-multiple-rules",
-      expect.getState().currentTestName,
-    );
+    await setupFromFixture("list-with-multiple-rules");
 
     const { stdout, code } = await runCommand("list");
 
@@ -17,10 +14,7 @@ describe("aicm list command with fixtures", () => {
   });
 
   test("should show message when no rules exist", async () => {
-    await setupFromFixture(
-      "list-with-no-rules",
-      expect.getState().currentTestName,
-    );
+    await setupFromFixture("install-no-rules");
 
     const { stdout, stderr, code } = await runCommand("list");
 

--- a/tests/e2e/presets.test.ts
+++ b/tests/e2e/presets.test.ts
@@ -8,10 +8,7 @@ import {
 
 describe("Presets with fixtures", () => {
   test("should install rules from a preset file", async () => {
-    await setupFromFixture(
-      "presets-from-file",
-      expect.getState().currentTestName,
-    );
+    await setupFromFixture("presets-from-file");
 
     const { code } = await runCommand("install --ci");
 
@@ -64,7 +61,7 @@ describe("Presets with fixtures", () => {
   });
 
   test("should merge rules from presets with main configuration", async () => {
-    await setupFromFixture("presets-merged", expect.getState().currentTestName);
+    await setupFromFixture("presets-merged");
 
     const { code } = await runCommand("install --ci");
 
@@ -113,7 +110,7 @@ describe("Presets with fixtures", () => {
   });
 
   test("should handle npm package presets from @company/ai-rules", async () => {
-    await setupFromFixture("presets-npm", expect.getState().currentTestName);
+    await setupFromFixture("presets-npm");
 
     const { code } = await runCommand("install --ci");
 
@@ -146,7 +143,7 @@ describe("Presets with fixtures", () => {
   });
 
   test("should support shorthand npm directory preset loading (loads aicm.json from directory)", async () => {
-    await setupFromFixture("presets-npm", expect.getState().currentTestName);
+    await setupFromFixture("presets-npm");
 
     const { code } = await runCommand("install --ci");
 
@@ -177,10 +174,7 @@ describe("Presets with fixtures", () => {
   });
 
   test("should handle errors with missing rule files", async () => {
-    await setupFromFixture(
-      "presets-missing-rules",
-      expect.getState().currentTestName,
-    );
+    await setupFromFixture("presets-missing-rules");
 
     const { stderr, code } = await runCommand("install --ci");
 
@@ -190,10 +184,7 @@ describe("Presets with fixtures", () => {
   });
 
   test("should handle errors with missing preset files", async () => {
-    await setupFromFixture(
-      "presets-missing-preset",
-      expect.getState().currentTestName,
-    );
+    await setupFromFixture("presets-missing-preset");
 
     const { stderr, code } = await runCommand("install --ci");
 
@@ -203,10 +194,7 @@ describe("Presets with fixtures", () => {
   });
 
   test("should override a rule and mcpServer from a preset", async () => {
-    await setupFromFixture(
-      "presets-npm-override",
-      expect.getState().currentTestName,
-    );
+    await setupFromFixture("presets-npm-override");
 
     const { code } = await runCommand("install --ci");
     expect(code).toBe(0);
@@ -232,10 +220,7 @@ describe("Presets with fixtures", () => {
 
   test("should cancel a rule and mcpServer from a preset when set to false", async () => {
     // Use a fixture with pre-canceled rules and mcpServers
-    await setupFromFixture(
-      "presets-cancel-rules",
-      expect.getState().currentTestName,
-    );
+    await setupFromFixture("presets-cancel-rules");
 
     const { code } = await runCommand("install --ci");
     expect(code).toBe(0);
@@ -253,10 +238,7 @@ describe("Presets with fixtures", () => {
   });
 
   test("should support namespaced directories for preset rules", async () => {
-    await setupFromFixture(
-      "presets-namespaced-dirs",
-      expect.getState().currentTestName,
-    );
+    await setupFromFixture("presets-namespaced-dirs");
 
     const { code } = await runCommand("install --ci");
 

--- a/tests/e2e/readme-example.test.ts
+++ b/tests/e2e/readme-example.test.ts
@@ -8,7 +8,7 @@ import path from "path";
 
 describe("README demo example", () => {
   test("should install rules from preset as shown in the README", async () => {
-    await setupFromFixture("readme-demo", expect.getState().currentTestName);
+    await setupFromFixture("readme-demo");
     const npmResult = await runNpmInstall("pirate-coding");
     expect(npmResult.code).toBe(0);
     const { stdout, code } = await runCommand("install --ci");

--- a/tests/e2e/windsurf.test.ts
+++ b/tests/e2e/windsurf.test.ts
@@ -11,7 +11,7 @@ import { parseMdcFile } from "../../src/utils/mdc-parser";
 
 describe("aicm windsurf integration", () => {
   test("should install rules to .aicm directory and update .windsurfrules", async () => {
-    await setupFromFixture("windsurf-basic", expect.getState().currentTestName);
+    await setupFromFixture("windsurf-basic");
 
     const { stdout, code } = await runCommand("install --ide windsurf --ci");
 
@@ -45,10 +45,7 @@ describe("aicm windsurf integration", () => {
   });
 
   test("should update existing .windsurfrules file", async () => {
-    await setupFromFixture(
-      "windsurf-existing",
-      expect.getState().currentTestName,
-    );
+    await setupFromFixture("windsurf-existing");
 
     const { stdout, code } = await runCommand("install --ide windsurf --ci");
 
@@ -67,10 +64,7 @@ describe("aicm windsurf integration", () => {
   });
 
   test("should handle multiple rule types correctly", async () => {
-    await setupFromFixture(
-      "windsurf-multiple-types",
-      expect.getState().currentTestName,
-    );
+    await setupFromFixture("windsurf-multiple-types");
 
     const { stdout, code } = await runCommand("install --ide windsurf --ci");
 
@@ -106,10 +100,7 @@ describe("aicm windsurf integration", () => {
   });
 
   test("should install multiple rules with a single command", async () => {
-    await setupFromFixture(
-      "windsurf-multiple-command",
-      expect.getState().currentTestName,
-    );
+    await setupFromFixture("windsurf-multiple-command");
 
     const { stdout, code } = await runCommand("install --ide windsurf --ci");
 
@@ -179,10 +170,7 @@ This rule is used to test appending markers to an existing file without markers.
   });
 
   test("should install rules into specified subdirectory when rule key includes a directory", async () => {
-    await setupFromFixture(
-      "windsurf-rule-in-subdir",
-      expect.getState().currentTestName,
-    );
+    await setupFromFixture("windsurf-rule-in-subdir");
 
     const { code } = await runCommand("install --ide windsurf --ci");
 
@@ -203,7 +191,7 @@ This rule is used to test appending markers to an existing file without markers.
   });
 
   test("should install rules to .aicm directory and update .windsurfrules", async () => {
-    await setupFromFixture("windsurf-basic", expect.getState().currentTestName);
+    await setupFromFixture("windsurf-basic");
 
     const { stdout, code } = await runCommand("install --ide windsurf --ci");
 
@@ -237,10 +225,7 @@ This rule is used to test appending markers to an existing file without markers.
   });
 
   test("should update existing .windsurfrules file", async () => {
-    await setupFromFixture(
-      "windsurf-existing",
-      expect.getState().currentTestName,
-    );
+    await setupFromFixture("windsurf-existing");
 
     const { stdout, code } = await runCommand("install --ide windsurf --ci");
 
@@ -259,10 +244,7 @@ This rule is used to test appending markers to an existing file without markers.
   });
 
   test("should handle multiple rule types correctly", async () => {
-    await setupFromFixture(
-      "windsurf-multiple-types",
-      expect.getState().currentTestName,
-    );
+    await setupFromFixture("windsurf-multiple-types");
 
     const { stdout, code } = await runCommand("install --ide windsurf --ci");
 
@@ -298,10 +280,7 @@ This rule is used to test appending markers to an existing file without markers.
   });
 
   test("should install multiple rules with a single command", async () => {
-    await setupFromFixture(
-      "windsurf-multiple-command",
-      expect.getState().currentTestName,
-    );
+    await setupFromFixture("windsurf-multiple-command");
 
     const { stdout, code } = await runCommand("install --ide windsurf --ci");
 
@@ -367,10 +346,7 @@ This rule is used to test appending markers to an existing file without markers.
   });
 
   test("should install rules into specified subdirectory when rule key includes a directory", async () => {
-    await setupFromFixture(
-      "windsurf-rule-in-subdir",
-      expect.getState().currentTestName,
-    );
+    await setupFromFixture("windsurf-rule-in-subdir");
     const { code } = await runCommand("install --ide windsurf --ci");
     expect(code).toBe(0);
 


### PR DESCRIPTION
It's easier to debug when each test goes to a directory of its own.

<img width="330" alt="image" src="https://github.com/user-attachments/assets/a77a48f7-e7b3-4bec-b9fb-305a589b3746" />
