### PR TITLE
fix: preserve existing mcp configuration

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -103,13 +103,27 @@ function writeMcpServersToTargets(
   if (!mcpServers) return;
   for (const ide of ides) {
     let mcpPath: string | null = null;
+
+    // Windsurf does not support project mcpServers, so skip
     if (ide === "cursor") {
       mcpPath = path.join(cwd, ".cursor", "mcp.json");
       fs.ensureDirSync(path.dirname(mcpPath));
     }
-    // Windsurf does not support project mcpServers, so skip
+
     if (mcpPath) {
-      fs.writeJsonSync(mcpPath, { mcpServers }, { spaces: 2 });
+      const existingConfig = fs.existsSync(mcpPath)
+        ? fs.readJsonSync(mcpPath)
+        : {};
+
+      const mergedConfig = {
+        ...existingConfig,
+        mcpServers: {
+          ...existingConfig.mcpServers,
+          ...mcpServers,
+        },
+      };
+
+      fs.writeJsonSync(mcpPath, mergedConfig, { spaces: 2 });
     }
   }
 }

--- a/tests/fixtures/install-mcp-override-same-key/.cursor/mcp.json
+++ b/tests/fixtures/install-mcp-override-same-key/.cursor/mcp.json
@@ -1,0 +1,17 @@
+{
+  "mcpServers": {
+    "shared-server": {
+      "command": "./old-scripts/old-server.sh",
+      "args": ["--old"],
+      "env": { "OLD_TOKEN": "old123" }
+    },
+    "user-only-server": {
+      "url": "https://user.example.com/mcp-only",
+      "env": { "USER_ONLY_TOKEN": "useronly456" }
+    }
+  },
+  "userSettings": {
+    "editor": "vim",
+    "fontSize": 14
+  }
+}

--- a/tests/fixtures/install-mcp-override-same-key/aicm.json
+++ b/tests/fixtures/install-mcp-override-same-key/aicm.json
@@ -1,0 +1,17 @@
+{
+  "ides": ["cursor"],
+  "rules": {
+    "override-test-rule": "./rules/override-test-rule.mdc"
+  },
+  "mcpServers": {
+    "shared-server": {
+      "command": "./scripts/aicm-updated-server.sh",
+      "args": ["--aicm-updated"],
+      "env": { "AICM_TOKEN": "aicm-new-token" }
+    },
+    "aicm-only-server": {
+      "command": "./scripts/aicm-only.sh",
+      "env": { "AICM_ONLY": "true" }
+    }
+  }
+}

--- a/tests/fixtures/install-mcp-override-same-key/rules/override-test-rule.mdc
+++ b/tests/fixtures/install-mcp-override-same-key/rules/override-test-rule.mdc
@@ -1,0 +1,5 @@
+---
+description:
+globs:
+alwaysApply: false
+---

--- a/tests/fixtures/install-mcp-preserve-existing/.cursor/mcp.json
+++ b/tests/fixtures/install-mcp-preserve-existing/.cursor/mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "user-defined-server": {
+      "command": "./user-scripts/user-server.sh",
+      "args": ["--user"],
+      "env": { "USER_TOKEN": "user123" }
+    },
+    "another-user-server": {
+      "url": "https://user.example.com/mcp",
+      "env": { "USER_API_KEY": "user456" }
+    }
+  }
+}

--- a/tests/fixtures/install-mcp-preserve-existing/aicm.json
+++ b/tests/fixtures/install-mcp-preserve-existing/aicm.json
@@ -1,0 +1,13 @@
+{
+  "ides": ["cursor"],
+  "rules": {
+    "test-rule": "./rules/test-rule.mdc"
+  },
+  "mcpServers": {
+    "aicm-managed-server": {
+      "command": "./scripts/aicm-server.sh",
+      "args": ["--aicm"],
+      "env": { "AICM_TOKEN": "aicm123" }
+    }
+  }
+}

--- a/tests/fixtures/install-mcp-preserve-existing/rules/test-rule.mdc
+++ b/tests/fixtures/install-mcp-preserve-existing/rules/test-rule.mdc
@@ -1,0 +1,5 @@
+---
+description:
+globs:
+alwaysApply: false
+---


### PR DESCRIPTION
Today we're re-writing the mcp configurations, essentially deleting existing configurations.

This PR makes it so the mcp configurations are added to the existing ones