### PR TITLE
feat: mark managed mcp configurations

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -13,11 +13,10 @@ import {
   addRuleToCollection,
 } from "../utils/rule-collector";
 import { writeRulesToTargets } from "../utils/rule-writer";
-import fs from "fs-extra";
-import path from "node:path";
 import { isCI } from "ci-info";
 import { discoverPackagesWithAicm } from "./workspaces/discovery";
 import { installWorkspacesPackages } from "./workspaces/workspaces-install";
+import { writeMcpServersToTargets } from "../utils/mcp-writer";
 
 /**
  * Options for the installCore function
@@ -85,45 +84,6 @@ async function withWorkingDirectory<T>(
   } finally {
     if (targetDir !== originalCwd) {
       process.chdir(originalCwd);
-    }
-  }
-}
-
-/**
- * Write MCP servers configuration to IDE targets
- * @param mcpServers The MCP servers configuration
- * @param ides The IDEs to write to
- * @param cwd The current working directory
- */
-function writeMcpServersToTargets(
-  mcpServers: Config["mcpServers"],
-  ides: string[],
-  cwd: string,
-): void {
-  if (!mcpServers) return;
-  for (const ide of ides) {
-    let mcpPath: string | null = null;
-
-    // Windsurf does not support project mcpServers, so skip
-    if (ide === "cursor") {
-      mcpPath = path.join(cwd, ".cursor", "mcp.json");
-      fs.ensureDirSync(path.dirname(mcpPath));
-    }
-
-    if (mcpPath) {
-      const existingConfig = fs.existsSync(mcpPath)
-        ? fs.readJsonSync(mcpPath)
-        : {};
-
-      const mergedConfig = {
-        ...existingConfig,
-        mcpServers: {
-          ...existingConfig.mcpServers,
-          ...mcpServers,
-        },
-      };
-
-      fs.writeJsonSync(mcpPath, mergedConfig, { spaces: 2 });
     }
   }
 }

--- a/src/utils/mcp-writer.ts
+++ b/src/utils/mcp-writer.ts
@@ -1,0 +1,79 @@
+import fs from "fs-extra";
+import path from "node:path";
+import { Config } from "../types";
+
+/**
+ * Write MCP servers configuration to IDE targets
+ * @param mcpServers The MCP servers configuration
+ * @param ides The IDEs to write to
+ * @param cwd The current working directory
+ */
+export function writeMcpServersToTargets(
+  mcpServers: Config["mcpServers"],
+  ides: string[],
+  cwd: string,
+): void {
+  if (!mcpServers) return;
+
+  for (const ide of ides) {
+    if (ide === "cursor") {
+      const mcpPath = path.join(cwd, ".cursor", "mcp.json");
+      writeMcpServersToFile(mcpServers, mcpPath);
+    }
+    // Windsurf does not support project mcpServers, so skip
+  }
+}
+
+/**
+ * Write MCP servers configuration to a specific file
+ * @param mcpServers The MCP servers configuration
+ * @param mcpPath The path to the mcp.json file
+ */
+export function writeMcpServersToFile(
+  mcpServers: Config["mcpServers"],
+  mcpPath: string,
+): void {
+  if (!mcpServers) return;
+  fs.ensureDirSync(path.dirname(mcpPath));
+
+  const existingConfig: Record<string, unknown> = fs.existsSync(mcpPath)
+    ? fs.readJsonSync(mcpPath)
+    : {};
+
+  const existingMcpServers = existingConfig?.mcpServers ?? {};
+
+  // Filter out any existing aicm-managed servers (with aicm: true)
+  // This removes stale aicm servers that are no longer in the configuration
+  const userMcpServers: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(existingMcpServers)) {
+    if (typeof value === "object" && value !== null && !value.aicm) {
+      userMcpServers[key] = value;
+    }
+  }
+
+  // Mark new aicm servers as managed and filter out canceled servers
+  const aicmMcpServers: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(mcpServers)) {
+    if (value !== false) {
+      aicmMcpServers[key] = {
+        ...value,
+        aicm: true,
+      };
+    }
+  }
+
+  // Merge user servers with aicm servers (aicm servers override user servers with same key)
+  const mergedMcpServers = {
+    ...userMcpServers,
+    ...aicmMcpServers,
+  };
+
+  const mergedConfig = {
+    ...existingConfig,
+    mcpServers: mergedMcpServers,
+  };
+
+  fs.writeJsonSync(mcpPath, mergedConfig, { spaces: 2 });
+}

--- a/src/utils/mcp-writer.ts
+++ b/src/utils/mcp-writer.ts
@@ -47,7 +47,7 @@ export function writeMcpServersToFile(
   const userMcpServers: Record<string, unknown> = {};
 
   for (const [key, value] of Object.entries(existingMcpServers)) {
-    if (typeof value === "object" && value !== null && !value.aicm) {
+    if (typeof value === "object" && value !== null && value.aicm !== true) {
       userMcpServers[key] = value;
     }
   }

--- a/tests/e2e/presets.test.ts
+++ b/tests/e2e/presets.test.ts
@@ -107,6 +107,7 @@ describe("Presets with fixtures", () => {
     expect(mcpConfig.mcpServers["preset-mcp"]).toMatchObject({
       command: "./scripts/preset-mcp.sh",
       env: { MCP_TOKEN: "preset" },
+      aicm: true,
     });
   });
 
@@ -214,6 +215,7 @@ describe("Presets with fixtures", () => {
     expect(mcpConfig.mcpServers["preset-mcp"]).toMatchObject({
       command: "./scripts/override-mcp.sh",
       env: { MCP_TOKEN: "override" },
+      aicm: true,
     });
   });
 

--- a/tests/fixtures/install-mcp-canceled-servers/.cursor/mcp.json
+++ b/tests/fixtures/install-mcp-canceled-servers/.cursor/mcp.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "user-server": {
+      "command": "./user-scripts/user-server.sh",
+      "env": { "USER_TOKEN": "user123" }
+    },
+    "canceled-server": {
+      "command": "./scripts/will-be-canceled.sh",
+      "env": { "CANCEL_TOKEN": "cancel456" },
+      "aicm": true
+    }
+  },
+  "userConfig": {
+    "setting": "preserve-this"
+  }
+}

--- a/tests/fixtures/install-mcp-canceled-servers/aicm.json
+++ b/tests/fixtures/install-mcp-canceled-servers/aicm.json
@@ -1,0 +1,13 @@
+{
+  "ides": ["cursor"],
+  "rules": {
+    "cancel-test-rule": "./rules/cancel-test-rule.mdc"
+  },
+  "mcpServers": {
+    "active-server": {
+      "command": "./scripts/active-server.sh",
+      "env": { "ACTIVE_TOKEN": "active123" }
+    },
+    "canceled-server": false
+  }
+}

--- a/tests/fixtures/install-mcp-canceled-servers/rules/cancel-test-rule.mdc
+++ b/tests/fixtures/install-mcp-canceled-servers/rules/cancel-test-rule.mdc
@@ -1,0 +1,5 @@
+---
+description:
+globs:
+alwaysApply: false
+---

--- a/tests/fixtures/install-mcp-stale-cleanup/.cursor/mcp.json
+++ b/tests/fixtures/install-mcp-stale-cleanup/.cursor/mcp.json
@@ -1,0 +1,22 @@
+{
+  "mcpServers": {
+    "user-server": {
+      "command": "./user-scripts/user-server.sh",
+      "env": { "USER_TOKEN": "user789" }
+    },
+    "existing-aicm-server": {
+      "command": "./scripts/old-existing-server.sh",
+      "args": ["--old"],
+      "env": { "OLD_TOKEN": "old123" },
+      "aicm": true
+    },
+    "stale-aicm-server": {
+      "command": "./scripts/stale-server.sh",
+      "env": { "STALE_TOKEN": "stale456" },
+      "aicm": true
+    }
+  },
+  "userSettings": {
+    "preference": "keep-this"
+  }
+}

--- a/tests/fixtures/install-mcp-stale-cleanup/aicm.json
+++ b/tests/fixtures/install-mcp-stale-cleanup/aicm.json
@@ -1,0 +1,18 @@
+{
+  "ides": ["cursor"],
+  "rules": {
+    "cleanup-test-rule": "./rules/cleanup-test-rule.mdc"
+  },
+  "mcpServers": {
+    "new-aicm-server": {
+      "command": "./scripts/new-aicm-server.sh",
+      "args": ["--new"],
+      "env": { "NEW_TOKEN": "new123" }
+    },
+    "existing-aicm-server": {
+      "command": "./scripts/updated-existing-server.sh",
+      "args": ["--updated"],
+      "env": { "UPDATED_TOKEN": "updated456" }
+    }
+  }
+}

--- a/tests/fixtures/install-mcp-stale-cleanup/rules/cleanup-test-rule.mdc
+++ b/tests/fixtures/install-mcp-stale-cleanup/rules/cleanup-test-rule.mdc
@@ -1,0 +1,5 @@
+---
+description:
+globs:
+alwaysApply: false
+---

--- a/tests/unit/mcp-writer.test.ts
+++ b/tests/unit/mcp-writer.test.ts
@@ -1,0 +1,155 @@
+import fs from "fs-extra";
+import path from "node:path";
+import { writeMcpServersToFile } from "../../src/utils/mcp-writer";
+
+describe("MCP Writer", () => {
+  const testDir = path.join(__dirname, "..", "..", "tmp-test", "mcp-writer");
+  const mcpPath = path.join(testDir, "mcp.json");
+
+  beforeEach(() => {
+    fs.ensureDirSync(testDir);
+    fs.removeSync(mcpPath);
+  });
+
+  afterEach(() => {
+    fs.removeSync(testDir);
+  });
+
+  describe("writeMcpServersToFile", () => {
+    test("should create new mcp.json file with aicm flag", () => {
+      const mcpServers = {
+        "test-server": {
+          command: "./test.sh",
+          env: { TOKEN: "test123" },
+        },
+      };
+
+      writeMcpServersToFile(mcpServers, mcpPath);
+
+      expect(fs.existsSync(mcpPath)).toBe(true);
+      const config = fs.readJsonSync(mcpPath);
+      expect(config.mcpServers["test-server"]).toMatchObject({
+        command: "./test.sh",
+        env: { TOKEN: "test123" },
+        aicm: true,
+      });
+    });
+
+    test("should preserve user servers when adding aicm servers", () => {
+      // Setup existing file with user server
+      const existingConfig = {
+        mcpServers: {
+          "user-server": {
+            command: "./user.sh",
+            env: { USER_TOKEN: "user123" },
+          },
+        },
+        userSettings: {
+          theme: "dark",
+        },
+      };
+      fs.writeJsonSync(mcpPath, existingConfig, { spaces: 2 });
+
+      // Add aicm server
+      const mcpServers = {
+        "aicm-server": {
+          command: "./aicm.sh",
+          env: { AICM_TOKEN: "aicm123" },
+        },
+      };
+
+      writeMcpServersToFile(mcpServers, mcpPath);
+
+      const finalConfig = fs.readJsonSync(mcpPath);
+
+      // User server should be preserved without aicm flag
+      expect(finalConfig.mcpServers["user-server"]).toMatchObject({
+        command: "./user.sh",
+        env: { USER_TOKEN: "user123" },
+      });
+      expect(finalConfig.mcpServers["user-server"].aicm).toBeUndefined();
+
+      // AICM server should have aicm flag
+      expect(finalConfig.mcpServers["aicm-server"]).toMatchObject({
+        command: "./aicm.sh",
+        env: { AICM_TOKEN: "aicm123" },
+        aicm: true,
+      });
+
+      // Other settings should be preserved
+      expect(finalConfig.userSettings).toMatchObject({ theme: "dark" });
+    });
+
+    test("should clean up stale aicm servers", () => {
+      // Setup existing file with old aicm server
+      const existingConfig = {
+        mcpServers: {
+          "user-server": {
+            command: "./user.sh",
+          },
+          "old-aicm-server": {
+            command: "./old.sh",
+            aicm: true,
+          },
+          "current-aicm-server": {
+            command: "./old-current.sh",
+            aicm: true,
+          },
+        },
+      };
+      fs.writeJsonSync(mcpPath, existingConfig, { spaces: 2 });
+
+      // Install new aicm configuration (doesn't include old-aicm-server)
+      const mcpServers = {
+        "current-aicm-server": {
+          command: "./new-current.sh",
+          env: { TOKEN: "updated" },
+        },
+        "new-aicm-server": {
+          command: "./new.sh",
+        },
+      };
+
+      writeMcpServersToFile(mcpServers, mcpPath);
+
+      const finalConfig = fs.readJsonSync(mcpPath);
+
+      // User server should be preserved
+      expect(finalConfig.mcpServers["user-server"]).toBeDefined();
+
+      // Old aicm server should be removed
+      expect(finalConfig.mcpServers["old-aicm-server"]).toBeUndefined();
+
+      // Current aicm server should be updated
+      expect(finalConfig.mcpServers["current-aicm-server"]).toMatchObject({
+        command: "./new-current.sh",
+        env: { TOKEN: "updated" },
+        aicm: true,
+      });
+
+      // New aicm server should be added
+      expect(finalConfig.mcpServers["new-aicm-server"]).toMatchObject({
+        command: "./new.sh",
+        aicm: true,
+      });
+    });
+
+    test("should skip canceled servers (set to false)", () => {
+      const mcpServers = {
+        "active-server": {
+          command: "./active.sh",
+        },
+        "canceled-server": false as const,
+      };
+
+      writeMcpServersToFile(mcpServers, mcpPath);
+
+      const config = fs.readJsonSync(mcpPath);
+      expect(config.mcpServers["active-server"]).toMatchObject({
+        command: "./active.sh",
+        aicm: true,
+      });
+      expect(config.mcpServers["canceled-server"]).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
This PR add an "aicm" mark for managed mcp configurations.
The idea here is that presets will be able to delete or change them in the future, which will result with the project's mcp being deleted or modified as a result