### PR TITLE
Fix MDC metadata parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
     "ci-info": "^4.2.0",
     "cosmiconfig": "^9.0.0",
     "fast-glob": "^3.3.3",
-    "fs-extra": "^11.1.1"
-    ,
+    "fs-extra": "^11.1.1",
     "yaml": "^2.7.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "cosmiconfig": "^9.0.0",
     "fast-glob": "^3.3.3",
     "fs-extra": "^11.1.1"
+    ,
+    "yaml": "^2.7.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.26.0",

--- a/src/utils/mdc-parser.ts
+++ b/src/utils/mdc-parser.ts
@@ -1,4 +1,5 @@
 import fs from "fs-extra";
+import yaml from "yaml";
 
 /**
  * Parse an MDC file and extract its content
@@ -29,33 +30,18 @@ export function parseMdcFile(filePath: string): {
   const metadataStr = fileContent.substring(3, endOfMetadata).trim();
   const content = fileContent.substring(endOfMetadata + 3).trim();
 
-  const metadata: Record<string, boolean | string | string[]> = {};
+  let metadata: Record<string, boolean | string | string[]> = {};
 
-  metadataStr.split("\n").forEach((line) => {
-    const colonIndex = line.indexOf(":");
-    if (colonIndex !== -1) {
-      const key = line.substring(0, colonIndex).trim();
-      const valueStr = line.substring(colonIndex + 1).trim();
-
-      // Handle different value types
-      let value: boolean | string | string[] = "";
-
-      if (valueStr === "true") {
-        value = true;
-      } else if (valueStr === "false") {
-        value = false;
-      } else if (valueStr.startsWith('"') && valueStr.endsWith('"')) {
-        // Remove quotes from string values
-        value = valueStr.substring(1, valueStr.length - 1);
-      } else {
-        // Default to using the string value as is
-        value = valueStr;
+  if (metadataStr.length > 0) {
+    try {
+      const parsed = yaml.parse(metadataStr);
+      if (parsed && typeof parsed === "object") {
+        metadata = parsed as Record<string, boolean | string | string[]>;
       }
-
-      metadata[key] = value;
+    } catch (e) {
+      throw new Error(`Invalid metadata in ${filePath}: ${e instanceof Error ? e.message : String(e)}`);
     }
-  });
-
+  }
   return {
     metadata,
     content,

--- a/src/utils/mdc-parser.ts
+++ b/src/utils/mdc-parser.ts
@@ -39,7 +39,9 @@ export function parseMdcFile(filePath: string): {
         metadata = parsed as Record<string, boolean | string | string[]>;
       }
     } catch (e) {
-      throw new Error(`Invalid metadata in ${filePath}: ${e instanceof Error ? e.message : String(e)}`);
+      throw new Error(
+        `Invalid metadata in ${filePath}: ${e instanceof Error ? e.message : String(e)}`,
+      );
     }
   }
   return {

--- a/tests/unit/mdc-parser.test.ts
+++ b/tests/unit/mdc-parser.test.ts
@@ -126,7 +126,7 @@ globs: ["*.ts", "*.tsx"]
 
       expect(result.metadata.description).toBe("File pattern rule example");
       expect(result.metadata.alwaysApply).toBe(false);
-      expect(result.metadata.globs).toBe('["*.ts", "*.tsx"]');
+      expect(result.metadata.globs).toEqual(["*.ts", "*.tsx"]);
       expect(result.content).toBe(
         "## TypeScript Best Practices\n\n- Use strict type checking\n- Prefer interfaces over types for public APIs",
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3964,6 +3964,11 @@ yaml@^2.7.0:
   resolved "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz#44a247d1b88523855679ac7fa7cda6ed7e135cf6"
   integrity sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==
 
+yaml@^2.7.1:
+  version "2.8.0"
+  resolved "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz#15f8c9866211bdc2d3781a0890e44d4fa1a5fff6"
+  integrity sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==
+
 yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"


### PR DESCRIPTION
## Summary
- parse MDC metadata using YAML parser so arrays and complex values work
- update tests for new parser behavior
- add YAML as a dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840b5504f308325b01c27e6a9f4cfd6