### PR TITLE
Add codex AGENTS.md support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ dist/
 # windsurf
 .windsurfrules
 !tests/fixtures/*/.windsurfrules
+AGENTS.md
+!tests/fixtures/*/AGENTS.md
 
 # aicm
 .aicm

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ When you run `npx aicm install`, all rules from the preset will be installed to 
 ### Notes
 
 - Generated rules are always placed in a subdirectory for deterministic cleanup and easy gitignore.
- - Users may add `.cursor/rules/aicm/`, `.aicm/`, and `AGENTS.md` (for Codex) to their `.gitignore` if they do not want to track generated rules.
+- Users may add `.cursor/rules/aicm/`, `.aicm/`, and `AGENTS.md` (for Codex) to their `.gitignore` if they do not want to track generated rules.
 
 ### Overriding and Disabling Rules and MCP Servers from Presets
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ When you run `npx aicm install`, all rules from the preset will be installed to 
 ### Notes
 
 - Generated rules are always placed in a subdirectory for deterministic cleanup and easy gitignore.
-- Users may add `.cursor/rules/aicm/` and `.aicm/` (for Windsurf) to their `.gitignore` if they do not want to track generated rules.
+ - Users may add `.cursor/rules/aicm/`, `.aicm/`, and `AGENTS.md` (for Codex) to their `.gitignore` if they do not want to track generated rules.
 
 ### Overriding and Disabling Rules and MCP Servers from Presets
 
@@ -219,6 +219,7 @@ Example `aicm.json`:
 
   - `"cursor"`: For the Cursor IDE
   - `"windsurf"`: For the Windsurf IDE
+  - `"codex"`: For the Codex IDE
 
   > **Note:** The 'ides' field is default to `["cursor"]` if not specified.
 
@@ -292,6 +293,7 @@ Rules stored locally in your project or filesystem. Any path containing slashes 
 
 - **Cursor**: Rules are installed as individual `.mdc` files in the Cursor rules directory (`.cursor/rules/aicm/`), mcp servers are installed to `.cursor/mcp.json`
 - **Windsurf**: Rules are installed in the `.aicm` directory which should be added to your `.gitignore` file. Our approach for Windsurf is to create links from the `.windsurfrules` file to the respective rules in the `.aicm` directory. There is no support for local mcp servers at the moment.
+- **Codex**: Rules are installed in the `.aicm` directory and referenced from `AGENTS.md` using the same markers as Windsurf.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ When you run `npx aicm install`, all rules from the preset will be installed to 
 ### Notes
 
 - Generated rules are always placed in a subdirectory for deterministic cleanup and easy gitignore.
-- Users may add `.cursor/rules/aicm/`, `.aicm/` to their `.gitignore` if they do not want to track generated rules.
+- Users may add `.cursor/rules/aicm/` and `.aicm/` (for Windsurf/Codex) to their `.gitignore` if they do not want to track generated rules.
 
 ### Overriding and Disabling Rules and MCP Servers from Presets
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ When you run `npx aicm install`, all rules from the preset will be installed to 
 ### Notes
 
 - Generated rules are always placed in a subdirectory for deterministic cleanup and easy gitignore.
-- Users may add `.cursor/rules/aicm/`, `.aicm/`, and `AGENTS.md` (for Codex) to their `.gitignore` if they do not want to track generated rules.
+- Users may add `.cursor/rules/aicm/`, `.aicm/` to their `.gitignore` if they do not want to track generated rules.
 
 ### Overriding and Disabling Rules and MCP Servers from Presets
 
@@ -219,7 +219,7 @@ Example `aicm.json`:
 
   - `"cursor"`: For the Cursor IDE
   - `"windsurf"`: For the Windsurf IDE
-  - `"codex"`: For the Codex IDE
+  - `"codex"`: For the Codex Agent
 
   > **Note:** The 'ides' field is default to `["cursor"]` if not specified.
 

--- a/aicm.json
+++ b/aicm.json
@@ -1,5 +1,5 @@
 {
-  "ides": ["cursor", "windsurf"],
+  "ides": ["cursor", "windsurf", "codex"],
   "rules": {
     "/": "./rules/*"
   },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -54,6 +54,7 @@ export interface RuleContent {
 export interface RuleCollection {
   cursor: RuleContent[];
   windsurf: RuleContent[];
+  codex: RuleContent[];
 }
 
 export interface PackageInfo {

--- a/src/utils/rule-collector.ts
+++ b/src/utils/rule-collector.ts
@@ -63,6 +63,7 @@ export function initRuleCollection(): RuleCollection {
   return {
     cursor: [],
     windsurf: [],
+    codex: [],
   };
 }
 
@@ -88,6 +89,11 @@ export function addRuleToCollection(
       !collection.windsurf.some((r) => r.name === rule.name)
     ) {
       collection.windsurf.push(rule);
+    } else if (
+      ide === "codex" &&
+      !collection.codex.some((r) => r.name === rule.name)
+    ) {
+      collection.codex.push(rule);
     }
   }
 }

--- a/src/utils/rule-status.ts
+++ b/src/utils/rule-status.ts
@@ -10,6 +10,7 @@ export function getIdePaths(): Record<string, string> {
   return {
     cursor: path.join(projectDir, ".cursor", "rules", "aicm"),
     windsurf: path.join(projectDir, ".aicm"),
+    codex: path.join(projectDir, ".aicm"),
   };
 }
 
@@ -39,6 +40,20 @@ export function checkRuleStatus(ruleName: string, ides: string[]): boolean {
         return (
           ruleExists && windsurfRulesContent.includes(`.aicm/${ruleName}.md`)
         );
+      }
+
+      return false;
+    }
+
+    if (ide === "codex") {
+      const ruleExists = fs.existsSync(
+        path.join(idePaths[ide], `${ruleName}.md`),
+      );
+
+      const codexFilePath = path.join(process.cwd(), "AGENTS.md");
+      if (fs.existsSync(codexFilePath)) {
+        const codexContent = fs.readFileSync(codexFilePath, "utf8");
+        return ruleExists && codexContent.includes(`.aicm/${ruleName}.md`);
       }
 
       return false;

--- a/src/utils/rule-writer.ts
+++ b/src/utils/rule-writer.ts
@@ -3,9 +3,9 @@ import path from "node:path";
 import { getIdePaths } from "./rule-status";
 import { RuleCollection, RuleContent } from "../types";
 import {
-  writeWindsurfRules,
-  generateWindsurfRulesContent,
-} from "./windsurf-writer";
+  writeRulesFile,
+  generateRulesFileContent,
+} from "./rules-file-writer";
 
 /**
  * Write all collected rules to their respective IDE targets
@@ -21,7 +21,15 @@ export function writeRulesToTargets(collection: RuleCollection): void {
 
   // Write Windsurf rules
   if (collection.windsurf.length > 0) {
-    writeWindsurfRulesFromCollection(collection.windsurf, idePaths.windsurf);
+    writeRulesForFile(
+      collection.windsurf,
+      idePaths.windsurf,
+      ".windsurfrules",
+    );
+  }
+
+  if (collection.codex.length > 0) {
+    writeRulesForFile(collection.codex, idePaths.codex, "AGENTS.md");
   }
 }
 
@@ -79,12 +87,13 @@ function writeCursorRules(rules: RuleContent[], cursorRulesDir: string): void {
 }
 
 /**
- * Write rules to Windsurf's rules directory and update .windsurfrules file
+ * Write rules to a shared directory and update the given rules file
  * @param rules The rules to write
  */
-function writeWindsurfRulesFromCollection(
+function writeRulesForFile(
   rules: RuleContent[],
   ruleDir: string,
+  rulesFile: string,
 ): void {
   fs.emptyDirSync(ruleDir);
 
@@ -110,7 +119,7 @@ function writeWindsurfRulesFromCollection(
 
     const relativeRuleDir = path.basename(ruleDir); // Gets '.rules'
 
-    // For the Windsurf rules file, we need to maintain the same structure
+    // For the rules file, maintain the same structure
     let windsurfPath;
     if (rule.presetPath) {
       const namespace = extractNamespaceFromPresetPath(rule.presetPath);
@@ -130,6 +139,6 @@ function writeWindsurfRulesFromCollection(
     };
   });
 
-  const windsurfRulesContent = generateWindsurfRulesContent(ruleFiles);
-  writeWindsurfRules(windsurfRulesContent);
+  const windsurfRulesContent = generateRulesFileContent(ruleFiles);
+  writeRulesFile(windsurfRulesContent, path.join(process.cwd(), rulesFile));
 }

--- a/src/utils/rule-writer.ts
+++ b/src/utils/rule-writer.ts
@@ -2,10 +2,7 @@ import fs from "fs-extra";
 import path from "node:path";
 import { getIdePaths } from "./rule-status";
 import { RuleCollection, RuleContent } from "../types";
-import {
-  writeRulesFile,
-  generateRulesFileContent,
-} from "./rules-file-writer";
+import { writeRulesFile, generateRulesFileContent } from "./rules-file-writer";
 
 /**
  * Write all collected rules to their respective IDE targets
@@ -21,11 +18,7 @@ export function writeRulesToTargets(collection: RuleCollection): void {
 
   // Write Windsurf rules
   if (collection.windsurf.length > 0) {
-    writeRulesForFile(
-      collection.windsurf,
-      idePaths.windsurf,
-      ".windsurfrules",
-    );
+    writeRulesForFile(collection.windsurf, idePaths.windsurf, ".windsurfrules");
   }
 
   if (collection.codex.length > 0) {

--- a/src/utils/rules-file-writer.ts
+++ b/src/utils/rules-file-writer.ts
@@ -154,9 +154,3 @@ export function generateRulesFileContent(
 
   return content.trim();
 }
-
-// Backwards compatibility exports
-export {
-  writeRulesFile as writeWindsurfRules,
-  generateRulesFileContent as generateWindsurfRulesContent,
-};

--- a/src/utils/rules-file-writer.ts
+++ b/src/utils/rules-file-writer.ts
@@ -24,7 +24,7 @@ ${RULES_END}`;
  * If the file doesn't exist, it will create it
  * If the markers don't exist, it will append them to the existing content
  */
-export function writeWindsurfRules(
+export function writeRulesFile(
   rulesContent: string,
   rulesFilePath: string = path.join(process.cwd(), ".windsurfrules"),
 ): void {
@@ -69,9 +69,9 @@ export function writeWindsurfRules(
 }
 
 /**
- * Generate the Windsurf rules content based on rule files
+ * Generate the rules file content based on rule files
  */
-export function generateWindsurfRulesContent(
+export function generateRulesFileContent(
   ruleFiles: {
     name: string;
     path: string;
@@ -154,3 +154,9 @@ export function generateWindsurfRulesContent(
 
   return content.trim();
 }
+
+// Backwards compatibility exports
+export {
+  writeRulesFile as writeWindsurfRules,
+  generateRulesFileContent as generateWindsurfRulesContent,
+};

--- a/tests/e2e/codex.test.ts
+++ b/tests/e2e/codex.test.ts
@@ -1,0 +1,66 @@
+import path from "path";
+import fs from "fs-extra";
+import {
+  setupFromFixture,
+  runCommand,
+  fileExists,
+  readTestFile,
+  testDir,
+} from "./helpers";
+
+describe("aicm codex integration", () => {
+  test("should install rules and update AGENTS.md", async () => {
+    await setupFromFixture("codex-basic");
+
+    const { stdout } = await runCommand("install --ide codex --ci");
+    expect(stdout).toContain("Rules installation completed");
+
+    expect(fileExists(path.join(".aicm", "always-rule.md"))).toBe(true);
+    expect(fileExists(path.join(".aicm", "opt-in-rule.md"))).toBe(true);
+    expect(fileExists(path.join(".aicm", "file-pattern-rule.md"))).toBe(true);
+
+    expect(fileExists("AGENTS.md")).toBe(true);
+    const agentsContent = readTestFile("AGENTS.md");
+    expect(agentsContent).toContain("<!-- AICM:BEGIN -->");
+    expect(agentsContent).toContain("<!-- AICM:END -->");
+    expect(agentsContent).toContain("[*.ts] .aicm/file-pattern-rule.md");
+  });
+
+  test("should append markers to existing file without markers", async () => {
+    await setupFromFixture("codex-no-markers");
+
+    const testDirPath = testDir;
+    fs.ensureDirSync(path.join(testDirPath, "rules"));
+    const ruleContent = `---
+description: "Rule for testing appending markers"
+type: "always"
+---
+
+# No Marker Rule
+
+This rule is used to test appending markers to an existing file without markers.`;
+    fs.writeFileSync(
+      path.join(testDirPath, "rules/no-marker-rule.mdc"),
+      ruleContent,
+    );
+
+    const existingContent = "# Existing Codex Rules\n\nThese are some existing rules.";
+    fs.writeFileSync(path.join(testDirPath, "AGENTS.md"), existingContent);
+
+    const { stdout } = await runCommand(
+      "install no-marker-rule ./rules/no-marker-rule.mdc --ide codex --ci",
+    );
+    expect(stdout).toContain("Rules installation completed");
+
+    const agentsContent = readTestFile("AGENTS.md");
+    expect(agentsContent).toContain("# Existing Codex Rules");
+    expect(agentsContent).toContain("These are some existing rules.");
+    expect(agentsContent).toContain("<!-- AICM:BEGIN -->");
+    expect(agentsContent).toContain("<!-- AICM:END -->");
+    expect(agentsContent).toContain(".aicm/no-marker-rule.md");
+
+    const beginMarkerIndex = agentsContent.indexOf("<!-- AICM:BEGIN -->");
+    const existingContentIndex = agentsContent.indexOf("# Existing Codex Rules");
+    expect(existingContentIndex).toBeLessThan(beginMarkerIndex);
+  });
+});

--- a/tests/e2e/codex.test.ts
+++ b/tests/e2e/codex.test.ts
@@ -44,7 +44,8 @@ This rule is used to test appending markers to an existing file without markers.
       ruleContent,
     );
 
-    const existingContent = "# Existing Codex Rules\n\nThese are some existing rules.";
+    const existingContent =
+      "# Existing Codex Rules\n\nThese are some existing rules.";
     fs.writeFileSync(path.join(testDirPath, "AGENTS.md"), existingContent);
 
     const { stdout } = await runCommand(
@@ -60,7 +61,9 @@ This rule is used to test appending markers to an existing file without markers.
     expect(agentsContent).toContain(".aicm/no-marker-rule.md");
 
     const beginMarkerIndex = agentsContent.indexOf("<!-- AICM:BEGIN -->");
-    const existingContentIndex = agentsContent.indexOf("# Existing Codex Rules");
+    const existingContentIndex = agentsContent.indexOf(
+      "# Existing Codex Rules",
+    );
     expect(existingContentIndex).toBeLessThan(beginMarkerIndex);
   });
 });

--- a/tests/fixtures/codex-basic/aicm.json
+++ b/tests/fixtures/codex-basic/aicm.json
@@ -1,0 +1,9 @@
+{
+  "ides": ["codex"],
+  "rules": {
+    "always-rule": "./rules/always-rule.mdc",
+    "opt-in-rule": "./rules/opt-in-rule.mdc",
+    "file-pattern-rule": "./rules/file-pattern-rule.mdc"
+  },
+  "presets": []
+}

--- a/tests/fixtures/codex-basic/rules/always-rule.mdc
+++ b/tests/fixtures/codex-basic/rules/always-rule.mdc
@@ -1,0 +1,9 @@
+---
+alwaysApply: true
+---
+
+## Development Standards
+
+- Use yarn for package management
+- Development workflow: e2e tests → implementation → verification
+- Document all features in README.md

--- a/tests/fixtures/codex-basic/rules/file-pattern-rule.mdc
+++ b/tests/fixtures/codex-basic/rules/file-pattern-rule.mdc
@@ -1,0 +1,9 @@
+---
+globs: "*.ts"
+---
+
+## TypeScript Best Practices
+
+- Use strict type checking
+- Prefer interfaces over types for public APIs
+- Use optional chaining and nullish coalescing when appropriate

--- a/tests/fixtures/codex-basic/rules/opt-in-rule.mdc
+++ b/tests/fixtures/codex-basic/rules/opt-in-rule.mdc
@@ -1,0 +1,9 @@
+---
+alwaysApply: false
+---
+
+## E2E Testing Best Practices
+
+- Store initial test state in fixtures
+- Reference documentation: tests/E2E_TESTS.md
+- Include .gitkeep file in empty fixture directories

--- a/tests/fixtures/codex-no-markers/AGENTS.md
+++ b/tests/fixtures/codex-no-markers/AGENTS.md
@@ -1,0 +1,3 @@
+# Existing Codex Rules
+
+These are some existing rules.

--- a/tests/fixtures/codex-no-markers/aicm.json
+++ b/tests/fixtures/codex-no-markers/aicm.json
@@ -1,0 +1,6 @@
+{
+  "ides": ["codex"],
+  "rules": {
+    "no-marker-rule": "./rules/no-marker-rule.mdc"
+  }
+}

--- a/tests/fixtures/codex-no-markers/rules/no-marker-rule.mdc
+++ b/tests/fixtures/codex-no-markers/rules/no-marker-rule.mdc
@@ -1,0 +1,8 @@
+---
+description: "Rule for testing appending markers"
+type: "always"
+---
+
+# No Marker Rule
+
+This rule is used to test appending markers to an existing file without markers.


### PR DESCRIPTION
## Summary
- support installing rules for the `codex` IDE
- generalize windsurf rule writer into `rules-file-writer`
- write codex rules into `AGENTS.md`
- update project config, ignore file and README for codex
- add e2e tests and fixtures for codex

## Testing
- `npm run test:all`

------
https://chatgpt.com/codex/tasks/task_e_6840ba356de88325aca4f520fde406ad