### PR TITLE
Simplify init config

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,16 @@ Initializes a new configuration file in your current directory.
 npx aicm init
 ```
 
+This generates a minimal `aicm.json`:
+
+```json
+{
+  "rules": {}
+}
+```
+
+Edit this file to add your rules, presets, or other settings.
+
 ### `install`
 
 Installs all rules and MCPs configured in your `aicm.json`.

--- a/README.md
+++ b/README.md
@@ -320,14 +320,6 @@ Initializes a new configuration file in your current directory.
 npx aicm init
 ```
 
-This generates a minimal `aicm.json`:
-
-```json
-{
-  "rules": {}
-}
-```
-
 Edit this file to add your rules, presets, or other settings.
 
 ### `install`

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -3,10 +3,7 @@ import path from "path";
 import chalk from "chalk";
 
 const defaultConfig = {
-  ides: ["cursor"],
   rules: {},
-  mcpServers: {},
-  installOnCI: false,
 };
 
 export function initCommand(): void {

--- a/tests/e2e/init.test.ts
+++ b/tests/e2e/init.test.ts
@@ -17,8 +17,7 @@ describe("aicm init command with fixtures", () => {
     expect(fileExists("aicm.json")).toBe(true);
 
     const config = JSON.parse(readTestFile("aicm.json"));
-    expect(config.ides).toBeDefined();
-    expect(config.rules).toBeDefined();
+    expect(config).toEqual({ rules: {} });
   });
 
   test("should not overwrite existing config", async () => {
@@ -32,6 +31,6 @@ describe("aicm init command with fixtures", () => {
     expect(fileExists("aicm.json")).toBe(true);
 
     const config = JSON.parse(readTestFile("aicm.json"));
-    expect(config.ides).toEqual(["custom"]);
+    expect(config).toEqual(customConfig);
   });
 });


### PR DESCRIPTION
## Summary
- simplify `aicm init` configuration
- test the simplified init output
- document minimal init config in README

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684219048f548325b11825762de90faf