### PR TITLE
Suppress preset warning

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -179,7 +179,7 @@ function processPresetsInternal(
 
     // Skip if we've already processed this preset (prevents circular references)
     if (processedPresets.has(pathInfo.fullPath)) {
-      console.warn(`Skipping already processed preset: ${presetPath}`);
+      // Skip duplicates to prevent circular references
       continue;
     }
 


### PR DESCRIPTION
## Summary
- remove console.warn when skipping previously processed presets
- revert suppress-logs setup

## Testing
- `pnpm test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_68421a221b88832585aa72d6db931b7d