### PR TITLE
Fix jest haste-map collisions

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,7 @@ module.exports = {
   clearMocks: true,
   resetMocks: false,
   testTimeout: 30000,
+  modulePathIgnorePatterns: ["<rootDir>/tests/fixtures", "<rootDir>/tmp-test"],
   globalSetup: "<rootDir>/tests/e2e/global-setup.ts",
   setupFilesAfterEnv: ["./tests/setup.ts"],
 };

--- a/jest.unit.config.js
+++ b/jest.unit.config.js
@@ -9,5 +9,6 @@ module.exports = {
   clearMocks: true,
   resetMocks: false,
   testTimeout: 5000,
+  modulePathIgnorePatterns: ["<rootDir>/tests/fixtures", "<rootDir>/tmp-test"],
   setupFilesAfterEnv: ["./tests/setup.ts"],
 };


### PR DESCRIPTION
## Summary
- ignore test fixtures and temp dir in jest configs to avoid haste-map name collisions

## Testing
- `pnpm format`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6844a170f4848325b86726c02ed049bf