### PR TITLE
Remove AGENTS fixture

### DIFF
--- a/tests/e2e/codex.test.ts
+++ b/tests/e2e/codex.test.ts
@@ -46,6 +46,8 @@ This rule is used to test appending markers to an existing file without markers.
 
     const existingContent =
       "# Existing Codex Rules\n\nThese are some existing rules.";
+    // AGENTS.md is created dynamically because Codex scans fixture paths
+    // and would treat a static fixture file as a real config.
     fs.writeFileSync(path.join(testDirPath, "AGENTS.md"), existingContent);
 
     const { stdout } = await runCommand(

--- a/tests/fixtures/codex-no-markers/AGENTS.md
+++ b/tests/fixtures/codex-no-markers/AGENTS.md
@@ -1,3 +1,0 @@
-# Existing Codex Rules
-
-These are some existing rules.


### PR DESCRIPTION
## Summary
- avoid having a static `AGENTS.md` test fixture so Codex doesn't scan it
- write the file dynamically in the Codex e2e test

## Testing
- `pnpm test:unit`
- `pnpm test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_6844a0e3123083258a971a1e702188da