### PR TITLE
fix: support having no root config in workspaces mode

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -8,6 +8,7 @@ import {
   RuleFile,
   MCPServers,
   SupportedTarget,
+  detectWorkspacesFromPackageJson,
 } from "../utils/config";
 import { withWorkingDirectory } from "../utils/working-directory";
 import { isCIEnvironment } from "../utils/is-ci";
@@ -679,7 +680,11 @@ export async function install(
       resolvedConfig = await loadConfig(cwd);
     }
 
-    if (resolvedConfig?.config.workspaces) {
+    const shouldUseWorkspaces =
+      resolvedConfig?.config.workspaces ||
+      (!resolvedConfig && detectWorkspacesFromPackageJson(cwd));
+
+    if (shouldUseWorkspaces) {
       return await installWorkspaces(cwd, installOnCI, options.verbose);
     }
 

--- a/tests/fixtures/workspaces-empty-root-config/aicm.json
+++ b/tests/fixtures/workspaces-empty-root-config/aicm.json
@@ -1,0 +1,4 @@
+{
+  "workspaces": true,
+  "targets": ["cursor"]
+}

--- a/tests/fixtures/workspaces-empty-root-config/package.json
+++ b/tests/fixtures/workspaces-empty-root-config/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "workspaces-empty-root-config-test",
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/tests/fixtures/workspaces-empty-root-config/packages/backend/aicm.json
+++ b/tests/fixtures/workspaces-empty-root-config/packages/backend/aicm.json
@@ -1,0 +1,4 @@
+{
+  "rulesDir": "./rules",
+  "targets": ["cursor"]
+}

--- a/tests/fixtures/workspaces-empty-root-config/packages/backend/rules/backend-rule.mdc
+++ b/tests/fixtures/workspaces-empty-root-config/packages/backend/rules/backend-rule.mdc
@@ -1,0 +1,8 @@
+---
+description:
+globs:
+alwaysApply: false
+---
+# Backend Development Rules (Empty Root Config)
+
+This rule is for the backend package in a workspace with an empty root config file.

--- a/tests/fixtures/workspaces-empty-root-config/packages/frontend/aicm.json
+++ b/tests/fixtures/workspaces-empty-root-config/packages/frontend/aicm.json
@@ -1,0 +1,4 @@
+{
+  "rulesDir": "./rules",
+  "targets": ["cursor"]
+}

--- a/tests/fixtures/workspaces-empty-root-config/packages/frontend/rules/frontend-rule.mdc
+++ b/tests/fixtures/workspaces-empty-root-config/packages/frontend/rules/frontend-rule.mdc
@@ -1,0 +1,8 @@
+---
+description:
+globs:
+alwaysApply: false
+---
+# Frontend Development Rules (Empty Root Config)
+
+This rule is for the frontend package in a workspace with an empty root config file.

--- a/tests/fixtures/workspaces-no-config/package.json
+++ b/tests/fixtures/workspaces-no-config/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "workspaces-no-config-test",
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/tests/fixtures/workspaces-no-config/packages/backend/aicm.json
+++ b/tests/fixtures/workspaces-no-config/packages/backend/aicm.json
@@ -1,0 +1,4 @@
+{
+  "rulesDir": "./rules",
+  "targets": ["cursor"]
+}

--- a/tests/fixtures/workspaces-no-config/packages/backend/rules/backend-rule.mdc
+++ b/tests/fixtures/workspaces-no-config/packages/backend/rules/backend-rule.mdc
@@ -1,0 +1,8 @@
+---
+description:
+globs:
+alwaysApply: false
+---
+# Backend Development Rules (No Config)
+
+This rule is for the backend package in a workspace with no root config file.

--- a/tests/fixtures/workspaces-no-config/packages/frontend/aicm.json
+++ b/tests/fixtures/workspaces-no-config/packages/frontend/aicm.json
@@ -1,0 +1,4 @@
+{
+  "rulesDir": "./rules",
+  "targets": ["cursor"]
+}

--- a/tests/fixtures/workspaces-no-config/packages/frontend/rules/frontend-rule.mdc
+++ b/tests/fixtures/workspaces-no-config/packages/frontend/rules/frontend-rule.mdc
@@ -1,0 +1,8 @@
+---
+description:
+globs:
+alwaysApply: false
+---
+# Frontend Development Rules (No Config)
+
+This rule is for the frontend package in a workspace with no root config file.


### PR DESCRIPTION
This PR adds support to having no config at the root in the case of workspaces mode