### PR TITLE
Fix init default config

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -3,7 +3,7 @@ import path from "path";
 import chalk from "chalk";
 
 const defaultConfig = {
-  rules: {},
+  rulesDir: "rules",
 };
 
 export function initCommand(): void {

--- a/tests/e2e/init.test.ts
+++ b/tests/e2e/init.test.ts
@@ -19,13 +19,13 @@ test("should create default config file", async () => {
   expect(fileExists("aicm.json")).toBe(true);
 
   const config = JSON.parse(readTestFile("aicm.json"));
-  expect(config).toEqual({ rules: {} });
+  expect(config).toEqual({ rulesDir: "rules" });
 });
 
 test("should not overwrite existing config", async () => {
   await setupFromFixture("no-config");
 
-  const customConfig = { ides: ["custom"], rules: {} };
+  const customConfig = { ides: ["custom"], rulesDir: "custom-rules" };
   fs.writeJsonSync(path.join(testDir, "aicm.json"), customConfig);
 
   const { stdout, code } = await runCommand("init");


### PR DESCRIPTION
## Summary
- create config with `rulesDir` when running `aicm init`
- update E2E tests accordingly

## Testing
- `pnpm test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_6847410987808325a5e8e3176308ffe7