### PR TITLE
Implement dry-run install mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Options:
 
 - `--ci`: run in CI environments (default: `false`)
 - `--verbose`: show detailed output and stack traces for debugging
+- `--dry-run`: simulate installation without writing files, useful for validating presets in CI
 
 ## Node.js API
 
@@ -290,6 +291,7 @@ Installs rules and MCP servers based on configuration.
 - `config`: Custom config object to use instead of loading from file
 - `installOnCI`: Run installation on CI environments (default: `false`)
 - `verbose`: Show verbose output and stack traces for debugging (default: `false`)
+- `dryRun`: Simulate installation without writing files, useful for preset validation in CI (default: `false`)
 
 **Returns:**
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,7 @@ export async function runCli() {
       "--version": Boolean,
       "--ci": Boolean,
       "--verbose": Boolean,
+      "--dry-run": Boolean,
       "-h": "--help",
       "-v": "--version",
     },
@@ -46,7 +47,11 @@ export async function runCli() {
         initCommand();
         break;
       case "install":
-        await installCommand(args["--ci"], args["--verbose"]);
+        await installCommand(
+          args["--ci"],
+          args["--verbose"],
+          args["--dry-run"],
+        );
         break;
       case "list":
         await listCommand();
@@ -78,10 +83,12 @@ ${chalk.bold("OPTIONS")}
   -v, --version       Show version number
   --ci                Run in CI environments (default: \`false\`)
   --verbose           Show detailed output and stack traces for debugging
+  --dry-run           Simulate installation without writing files, useful for validating presets in CI
 
 ${chalk.bold("EXAMPLES")}
   $ aicm init
   $ aicm install
+  $ aicm install --dry-run
   $ aicm list
 `);
 }

--- a/tests/e2e/api.test.ts
+++ b/tests/e2e/api.test.ts
@@ -55,3 +55,26 @@ test("handle missing config", async () => {
   expect(result.installedRuleCount).toBe(0);
   expect(result.packagesCount).toBe(0);
 });
+
+test("dry run API", async () => {
+  const testDir = await setupFromFixture("single-rule");
+
+  const result = await install({
+    cwd: testDir,
+    installOnCI: true,
+    dryRun: true,
+  });
+
+  expect(result.success).toBe(true);
+  expect(result.installedRuleCount).toBe(1);
+  expect(result.packagesCount).toBe(1);
+
+  const ruleFile = path.join(
+    testDir,
+    ".cursor",
+    "rules",
+    "aicm",
+    "test-rule.mdc",
+  );
+  expect(fs.existsSync(ruleFile)).toBe(false);
+});

--- a/tests/e2e/install.test.ts
+++ b/tests/e2e/install.test.ts
@@ -410,3 +410,19 @@ test("no mcp servers", async () => {
   const mcpPath = path.join(".cursor", "mcp.json");
   expect(fileExists(mcpPath)).toBe(false);
 });
+
+test("dry run does not write files", async () => {
+  await setupFromFixture("single-rule");
+
+  const { stdout, code } = await runCommand("install --ci --dry-run");
+
+  expect(code).toBe(0);
+  expect(stdout).toContain("Dry run");
+
+  expect(
+    fileExists(path.join(".cursor", "rules", "aicm", "test-rule.mdc")),
+  ).toBe(false);
+
+  const mcpPath = path.join(".cursor", "mcp.json");
+  expect(fileExists(mcpPath)).toBe(false);
+});


### PR DESCRIPTION
## Summary
- add `dryRun` option with CLI flag
- show validation message during dry run
- document that dry-run is intended for preset authors to validate installations

## Testing
- `pnpm format`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6847517afa0083259290a8a6c514f47b