### PR TITLE
fix: improve install logs

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -647,10 +647,6 @@ async function installWorkspaces(
       };
     }
 
-    console.log(
-      `Successfully installed ${result.totalRuleCount} rules across ${result.packages.length} packages`,
-    );
-
     return {
       success: true,
       installedRuleCount: result.totalRuleCount,
@@ -718,20 +714,22 @@ export async function installCommand(
   if (!result.success) {
     throw result.error ?? new Error("Installation failed with unknown error");
   } else {
+    const rulesInstalledMessage = `${result.installedRuleCount} rule${result.installedRuleCount === 1 ? "" : "s"}`;
+
     if (dryRun) {
       if (result.packagesCount > 1) {
         console.log(
-          `Dry run: ${result.installedRuleCount} rules across ${result.packagesCount} packages validated`,
+          `Dry run: validated ${rulesInstalledMessage} across ${result.packagesCount} packages`,
         );
       } else {
-        console.log("Dry run: configuration validated");
+        console.log(`Dry run: validated ${rulesInstalledMessage}`);
       }
     } else if (result.packagesCount > 1) {
       console.log(
-        `Successfully installed ${result.installedRuleCount} rules across ${result.packagesCount} packages`,
+        `Successfully installed ${rulesInstalledMessage} across ${result.packagesCount} packages`,
       );
     } else {
-      console.log("Rules installation completed");
+      console.log(`Successfully installed ${rulesInstalledMessage}`);
     }
   }
 }

--- a/tests/e2e/ci.test.ts
+++ b/tests/e2e/ci.test.ts
@@ -35,7 +35,7 @@ describe("CI", () => {
     });
 
     expect(code).toBe(0);
-    expect(stdout).toContain("Rules installation completed");
+    expect(stdout).toContain("Successfully installed 1 rule");
     expect(fileExists(cursorRulePath)).toBe(true);
 
     // Verify rule content
@@ -64,7 +64,7 @@ describe("CI", () => {
     });
 
     expect(code).toBe(0);
-    expect(stdout).toContain("Rules installation completed");
+    expect(stdout).toContain("Successfully installed 1 rule");
     expect(fileExists(cursorRulePath)).toBe(true);
 
     // Verify rule content
@@ -80,7 +80,7 @@ describe("CI", () => {
     });
 
     expect(code).toBe(0);
-    expect(stdout).toContain("Rules installation completed");
+    expect(stdout).toContain("Successfully installed 1 rule");
     expect(fileExists(cursorRulePath)).toBe(true);
 
     // Verify rule content

--- a/tests/e2e/codex.test.ts
+++ b/tests/e2e/codex.test.ts
@@ -14,7 +14,7 @@ describe("codex integration", () => {
     const { stdout, code } = await runCommand("install --ci");
 
     expect(code).toBe(0);
-    expect(stdout).toContain("Rules installation completed");
+    expect(stdout).toContain("Successfully installed 3 rules");
 
     // Check that rules were installed
     expect(fileExists(path.join(".aicm", "always-rule.md"))).toBe(true);
@@ -42,7 +42,7 @@ describe("codex integration", () => {
     const { stdout, code } = await runCommand("install --ci");
 
     expect(code).toBe(0);
-    expect(stdout).toContain("Rules installation completed");
+    expect(stdout).toContain("Successfully installed 1 rule");
 
     // Check that rule was installed
     expect(fileExists(path.join(".aicm", "no-marker-rule.md"))).toBe(true);

--- a/tests/e2e/install.test.ts
+++ b/tests/e2e/install.test.ts
@@ -13,7 +13,7 @@ test("single rule", async () => {
   const { stdout, code } = await runCommand("install --ci");
 
   expect(code).toBe(0);
-  expect(stdout).toContain("Rules installation completed");
+  expect(stdout).toContain("Successfully installed 1 rule");
 
   // Check that rule was installed
   expect(
@@ -72,7 +72,7 @@ test("handle missing rule files", async () => {
   const { stdout, code } = await runCommand("install --ci");
 
   expect(code).toBe(0);
-  expect(stdout).toContain("Rules installation completed");
+  expect(stdout).toContain("Successfully installed 2 rules");
 
   // Check that existing rule was installed
   expect(
@@ -89,7 +89,7 @@ test("multiple rules from rulesDir", async () => {
   const { stdout, code } = await runCommand("install --ci");
 
   expect(code).toBe(0);
-  expect(stdout).toContain("Rules installation completed");
+  expect(stdout).toContain("Successfully installed 3 rules");
 
   // Check that all rules were installed
   expect(fileExists(path.join(".cursor", "rules", "aicm", "rule1.mdc"))).toBe(
@@ -120,7 +120,7 @@ test("multiple targets", async () => {
   const { stdout, code } = await runCommand("install --ci");
 
   expect(code).toBe(0);
-  expect(stdout).toContain("Rules installation completed");
+  expect(stdout).toContain("Successfully installed 2 rules");
 
   // Check Cursor installation
   expect(
@@ -147,7 +147,7 @@ test("clean stale Cursor rules", async () => {
   const { stdout, code } = await runCommand("install --ci");
 
   expect(code).toBe(0);
-  expect(stdout).toContain("Rules installation completed");
+  expect(stdout).toContain("Successfully installed 1 rule");
 
   // Stale rule should be removed, new rule should exist
   expect(fileExists(staleRulePath)).toBe(false);
@@ -170,7 +170,7 @@ test("clean stale Windsurf rules", async () => {
   const { stdout, code } = await runCommand("install --ci");
 
   expect(code).toBe(0);
-  expect(stdout).toContain("Rules installation completed");
+  expect(stdout).toContain("Successfully installed 1 rule");
 
   // Stale rule should be removed
   expect(fileExists(path.join(".aicm", "stale-windsurf-rule.md"))).toBe(false);
@@ -373,7 +373,7 @@ test("rulesDir with subdirectories", async () => {
   const { stdout, code } = await runCommand("install --ci");
 
   expect(code).toBe(0);
-  expect(stdout).toContain("Rules installation completed");
+  expect(stdout).toContain("Successfully installed 1 rule");
 
   // Check that rule was installed in subdirectory
   expect(
@@ -399,7 +399,7 @@ test("no mcp servers", async () => {
   const { stdout, code } = await runCommand("install --ci");
 
   expect(code).toBe(0);
-  expect(stdout).toContain("Rules installation completed");
+  expect(stdout).toContain("Successfully installed 2 rules");
 
   // Check that rule was installed
   expect(

--- a/tests/e2e/presets.test.ts
+++ b/tests/e2e/presets.test.ts
@@ -13,7 +13,7 @@ test("install rules from a preset file", async () => {
   const { stdout, code } = await runCommand("install --ci");
 
   expect(code).toBe(0);
-  expect(stdout).toContain("Rules installation completed");
+  expect(stdout).toContain("Successfully installed 2 rules");
 
   // Check that rules from preset were installed with preset namespace
   expect(
@@ -68,7 +68,7 @@ test("merge rules from presets with main configuration", async () => {
   const { stdout, code } = await runCommand("install --ci");
 
   expect(code).toBe(0);
-  expect(stdout).toContain("Rules installation completed");
+  expect(stdout).toContain("Successfully installed 2 rules");
 
   // Check that preset rule was installed with preset namespace
   expect(
@@ -122,7 +122,7 @@ test("handle npm package presets", async () => {
   const { stdout, code } = await runCommand("install --ci");
 
   expect(code).toBe(0);
-  expect(stdout).toContain("Rules installation completed");
+  expect(stdout).toContain("Successfully installed 1 rule");
 
   // Check that npm package rule was installed with npm package namespace
   expect(
@@ -166,7 +166,7 @@ test("override a rule and mcpServer from a preset", async () => {
   const { stdout, code } = await runCommand("install --ci");
 
   expect(code).toBe(0);
-  expect(stdout).toContain("Rules installation completed");
+  expect(stdout).toContain("Successfully installed 2 rules");
 
   // Check that override rule was installed (not the original npm rule)
   expect(
@@ -194,7 +194,7 @@ test("install rules from preset only (no rulesDir)", async () => {
   const { stdout, code } = await runCommand("install --ci");
 
   expect(code).toBe(0);
-  expect(stdout).toContain("Rules installation completed");
+  expect(stdout).toContain("Successfully installed 1 rule");
 
   // Check that rules from preset were installed with preset namespace
   expect(

--- a/tests/e2e/readme-example.test.ts
+++ b/tests/e2e/readme-example.test.ts
@@ -6,7 +6,7 @@ test("should install rules from preset as shown in the README", async () => {
 
   const { stdout } = await runCommand("install --ci");
 
-  expect(stdout).toContain("Rules installation completed");
+  expect(stdout).toContain("Successfully installed 1 rule");
 
   expect(
     fileExists(

--- a/tests/e2e/windsurf.test.ts
+++ b/tests/e2e/windsurf.test.ts
@@ -12,7 +12,7 @@ test("should install rules to .aicm directory and update .windsurfrules", async 
   const { stdout, code } = await runCommand("install --ci");
 
   expect(code).toBe(0);
-  expect(stdout).toContain("Rules installation completed");
+  expect(stdout).toContain("Successfully installed 3 rules");
 
   expect(fileExists(path.join(".aicm", "always-rule.md"))).toBe(true);
   expect(fileExists(path.join(".aicm", "opt-in-rule.md"))).toBe(true);
@@ -49,7 +49,7 @@ test("should update existing .windsurfrules file", async () => {
   const { stdout, code } = await runCommand("install --ci");
 
   expect(code).toBe(0);
-  expect(stdout).toContain("Rules installation completed");
+  expect(stdout).toContain("Successfully installed 1 rule");
 
   const windsurfRulesContent = readTestFile(".windsurfrules");
 
@@ -78,12 +78,10 @@ test("should clean stale windsurf rules", async () => {
   const { stdout, code } = await runCommand("install --ci");
 
   expect(code).toBe(0);
-  expect(stdout).toContain("Rules installation completed");
+  expect(stdout).toContain("Successfully installed 1 rule");
 
-  // Stale rule should be removed
   expect(fileExists(path.join(".aicm", "stale-windsurf-rule.md"))).toBe(false);
 
-  // Fresh rule should be updated
   expect(fileExists(path.join(".aicm", "fresh-windsurf-rule.md"))).toBe(true);
   const freshRuleContent = readTestFile(
     path.join(".aicm", "fresh-windsurf-rule.md"),

--- a/tests/e2e/workspaces.test.ts
+++ b/tests/e2e/workspaces.test.ts
@@ -92,7 +92,7 @@ test("install normally when workspaces is enabled on single package", async () =
   expect(code).toBe(0);
   expect(stdout).toContain("Found 1 packages with aicm configurations:");
   expect(stdout).toContain("- .");
-  expect(stdout).toContain("Successfully installed 1 rules across 1 packages");
+  expect(stdout).toContain("Successfully installed 1 rule");
 
   expect(
     fileExists(path.join(".cursor", "rules", "aicm", "local-rule.mdc")),
@@ -393,7 +393,7 @@ test("explicit workspaces: false overrides auto-detection from package.json", as
   expect(stdout).not.toContain("🔍 Discovering packages...");
   expect(stdout).not.toContain("Found");
   expect(stdout).not.toContain("📦 Installing configurations...");
-  expect(stdout).toContain("Rules installation completed");
+  expect(stdout).toContain("Successfully installed 1 rule");
 
   // Check that rule was installed in root directory, not as workspace
   expect(


### PR DESCRIPTION
We had duplicated logs, in addition, it's nice to see how many rules were created in the success message.