### PR TITLE
Do not throw in case of 0 rules

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -439,19 +439,6 @@ export async function installPackage(
 
     const { config, rules, mcpServers } = resolvedConfig;
 
-    // Check if rules are defined (either directly or through presets)
-    if (!rules || rules.length === 0) {
-      // If there are no presets defined either, show a message
-      if (!config.presets || config.presets.length === 0) {
-        return {
-          success: false,
-          error: new Error("No rules defined in configuration"),
-          installedRuleCount: 0,
-          packagesCount: 0,
-        };
-      }
-    }
-
     try {
       if (!options.dryRun) {
         // Write rules to targets
@@ -724,6 +711,8 @@ export async function installCommand(
       } else {
         console.log(`Dry run: validated ${rulesInstalledMessage}`);
       }
+    } else if (result.installedRuleCount === 0) {
+      console.log(chalk.yellow("No rules installed."));
     } else if (result.packagesCount > 1) {
       console.log(
         `Successfully installed ${rulesInstalledMessage} across ${result.packagesCount} packages`,

--- a/tests/e2e/install.test.ts
+++ b/tests/e2e/install.test.ts
@@ -48,13 +48,13 @@ test("show error when no config file exists", async () => {
   expect(stderr).toMatch(/config|configuration|not found/i);
 });
 
-test("show error when no rules exist in rulesDir", async () => {
+test("no rules prints message", async () => {
   await setupFromFixture("empty-rules");
 
-  const { stderr, code } = await runFailedCommand("install --ci");
+  const { stdout, code } = await runCommand("install --ci");
 
-  expect(code).not.toBe(0);
-  expect(stderr).toContain("No rules defined in configuration");
+  expect(code).toBe(0);
+  expect(stdout).toContain("No rules installed");
 });
 
 test("unknown config keys throw error", async () => {
@@ -425,4 +425,22 @@ test("dry run does not write files", async () => {
 
   const mcpPath = path.join(".cursor", "mcp.json");
   expect(fileExists(mcpPath)).toBe(false);
+});
+
+test("override deleting last rule does not error", async () => {
+  await setupFromFixture("override-delete-rule");
+
+  const { stdout, code } = await runCommand("install --ci");
+
+  expect(code).toBe(0);
+  expect(stdout).toContain("No rules installed");
+
+  // Rule should not be installed
+  expect(
+    fileExists(path.join(".cursor", "rules", "aicm", "test-rule.mdc")),
+  ).toBe(false);
+
+  // MCP server should still be installed
+  const mcpPath = path.join(".cursor", "mcp.json");
+  expect(fileExists(mcpPath)).toBe(true);
 });

--- a/tests/e2e/workspaces.test.ts
+++ b/tests/e2e/workspaces.test.ts
@@ -277,20 +277,19 @@ test("discover and install rules from mixed workspaces + Bazel structure", async
   ).toBe(true);
 });
 
-test("handle error scenarios with invalid configurations", async () => {
+test("handle package missing rules gracefully", async () => {
   await setupFromFixture("workspaces-error-scenarios");
 
-  const { stdout, code } = await runFailedCommand("install --ci --verbose");
+  const { stdout, code } = await runCommand("install --ci --verbose");
 
-  expect(code).not.toBe(0);
+  expect(code).toBe(0);
   expect(stdout).toContain("🔍 Discovering packages...");
   expect(stdout).toContain("Found 2 packages with aicm configurations:");
   expect(stdout).toContain("- valid-package");
   expect(stdout).toContain("- missing-rule");
   expect(stdout).toContain("📦 Installing configurations...");
   expect(stdout).toContain("✅ valid-package (1 rules)");
-  expect(stdout).toContain("❌ missing-rule:");
-  expect(stdout).toContain("Installation completed with errors");
+  expect(stdout).toContain("✅ missing-rule (0 rules)");
 
   // Check that the valid package still installed successfully
   expect(

--- a/tests/fixtures/override-delete-rule/aicm.json
+++ b/tests/fixtures/override-delete-rule/aicm.json
@@ -1,0 +1,14 @@
+{
+  "rulesDir": "./rules",
+  "targets": ["cursor"],
+  "overrides": {
+    "test-rule": false
+  },
+  "mcpServers": {
+    "test-mcp": {
+      "command": "./scripts/test-mcp.sh",
+      "args": ["--test"],
+      "env": { "TEST_TOKEN": "test123" }
+    }
+  }
+}

--- a/tests/fixtures/override-delete-rule/rules/test-rule.mdc
+++ b/tests/fixtures/override-delete-rule/rules/test-rule.mdc
@@ -1,0 +1,6 @@
+---
+description:
+globs:
+alwaysApply: false
+---
+# Test Rule


### PR DESCRIPTION
## Summary
- remove error when rules list is empty
- log "No rules installed" if nothing is installed
- test override removing last rule

## Testing
- `pnpm format`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68508556157c8325b05a16b146fe4c17