### PR TITLE
feat: add jules target support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ aicm accepts Cursor's `.mdc` format as it provides the most comprehensive featur
 - **Cursor**: Native `.mdc` files with full feature support
 - **Windsurf**: Generates `.windsurfrules` file
 - **Codex**: Generates `AGENTS.md` file
+- **Jules**: Generates `AGENTS.md` file
 - **Claude**: Generates `CLAUDE.md` file
 
 This approach ensures you write your rules once in the richest format available, while maintaining compatibility across different AI development environments.
@@ -234,6 +235,7 @@ Create an `aicm.json` file in your project root, or an `aicm` key in your projec
 - **Cursor**: Rules are installed as individual `.mdc` files in the Cursor rules directory (`.cursor/rules/aicm/`), mcp servers are installed to `.cursor/mcp.json`
 - **Windsurf**: Rules are installed in the `.aicm` directory which should be added to your `.gitignore` file. Our approach for Windsurf is to create links from the `.windsurfrules` file to the respective rules in the `.aicm` directory. There is no support for local mcp servers at the moment.
 - **Codex**: Rules are installed in the `.aicm` directory and referenced from `AGENTS.md`.
+- **Jules**: Rules are installed in the `.aicm` directory and referenced from `AGENTS.md`.
 
 ## Commands
 

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -70,6 +70,7 @@ function getTargetPaths(): Record<string, string> {
     cursor: path.join(projectDir, ".cursor", "rules", "aicm"),
     windsurf: path.join(projectDir, ".aicm"),
     codex: path.join(projectDir, ".aicm"),
+    jules: path.join(projectDir, ".aicm"),
     claude: path.join(projectDir, ".aicm"),
   };
 }
@@ -190,6 +191,11 @@ function writeRulesToTargets(
           writeRulesForFile(rules, targetPaths.codex, "AGENTS.md");
         }
         break;
+      case "jules":
+        if (rules.length > 0) {
+          writeRulesForFile(rules, targetPaths.jules, "AGENTS.md");
+        }
+        break;
       case "claude":
         if (rules.length > 0) {
           writeRulesForFile(rules, targetPaths.claude, "CLAUDE.md");
@@ -214,7 +220,7 @@ function writeMcpServersToTargets(
       const mcpPath = path.join(cwd, ".cursor", "mcp.json");
       writeMcpServersToFile(mcpServers, mcpPath);
     }
-    // Windsurf and Codex do not support project mcpServers, so skip
+    // Windsurf, Codex, and Jules do not support project mcpServers, so skip
   }
 }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -74,6 +74,7 @@ export const SUPPORTED_TARGETS = [
   "cursor",
   "windsurf",
   "codex",
+  "jules",
   "claude",
 ] as const;
 export type SupportedTarget = (typeof SUPPORTED_TARGETS)[number];

--- a/tests/e2e/jules.test.ts
+++ b/tests/e2e/jules.test.ts
@@ -1,0 +1,77 @@
+import path from "path";
+import {
+  setupFromFixture,
+  runCommand,
+  fileExists,
+  readTestFile,
+  writeTestFile,
+} from "./helpers";
+
+describe("jules integration", () => {
+  test("should install rules and update AGENTS.md", async () => {
+    await setupFromFixture("jules-basic");
+
+    const { stdout, code } = await runCommand("install --ci");
+
+    expect(code).toBe(0);
+    expect(stdout).toContain("Successfully installed 3 rules");
+
+    // Check that rules were installed
+    expect(fileExists(path.join(".aicm", "always-rule.md"))).toBe(true);
+    expect(fileExists(path.join(".aicm", "opt-in-rule.md"))).toBe(true);
+    expect(fileExists(path.join(".aicm", "file-pattern-rule.md"))).toBe(true);
+
+    // Check that AGENTS.md was created/updated
+    expect(fileExists("AGENTS.md")).toBe(true);
+    const agentsContent = readTestFile("AGENTS.md");
+    expect(agentsContent).toContain("<!-- AICM:BEGIN -->");
+    expect(agentsContent).toContain("<!-- AICM:END -->");
+    expect(agentsContent).toContain(
+      "The following rules always apply to all files in the project:",
+    );
+    expect(agentsContent).toContain(
+      "The following rules can be loaded when relevant. Check each file's description:",
+    );
+    expect(agentsContent).toContain(
+      "The following rules are only included when explicitly referenced:",
+    );
+    expect(agentsContent).toContain("- .aicm/always-rule.md");
+    expect(agentsContent).toContain("- .aicm/file-pattern-rule.md");
+    expect(agentsContent).toContain("- .aicm/opt-in-rule.md");
+  });
+
+  test("should append markers to existing file without markers", async () => {
+    await setupFromFixture("jules-no-markers");
+
+    // Create existing AGENTS.md file without markers
+    const existingContent =
+      "# Existing Jules Rules\n\nThese are some existing rules.";
+    writeTestFile("AGENTS.md", existingContent);
+
+    const { stdout, code } = await runCommand("install --ci");
+
+    expect(code).toBe(0);
+    expect(stdout).toContain("Successfully installed 1 rule");
+
+    // Check that rule was installed
+    expect(fileExists(path.join(".aicm", "no-marker-rule.md"))).toBe(true);
+
+    // Check that AGENTS.md was updated with markers
+    const agentsContent = readTestFile("AGENTS.md");
+    expect(agentsContent).toContain("# Existing Jules Rules");
+    expect(agentsContent).toContain("These are some existing rules.");
+    expect(agentsContent).toContain("<!-- AICM:BEGIN -->");
+    expect(agentsContent).toContain("<!-- AICM:END -->");
+    expect(agentsContent).toContain(
+      "The following rules are only included when explicitly referenced:",
+    );
+    expect(agentsContent).toContain("- .aicm/no-marker-rule.md");
+
+    // Verify that existing content comes before AICM markers
+    const beginMarkerIndex = agentsContent.indexOf("<!-- AICM:BEGIN -->");
+    const existingContentIndex = agentsContent.indexOf(
+      "# Existing Jules Rules",
+    );
+    expect(existingContentIndex).toBeLessThan(beginMarkerIndex);
+  });
+});

--- a/tests/fixtures/jules-basic/aicm.json
+++ b/tests/fixtures/jules-basic/aicm.json
@@ -1,0 +1,4 @@
+{
+  "rulesDir": "./rules",
+  "targets": ["jules"]
+}

--- a/tests/fixtures/jules-basic/rules/always-rule.mdc
+++ b/tests/fixtures/jules-basic/rules/always-rule.mdc
@@ -1,0 +1,13 @@
+---
+description:
+globs:
+alwaysApply: false
+---
+---
+description: "Always applied rule for Codex"
+type: "always"
+---
+
+- Use yarn for package management
+- Development workflow: e2e tests → implementation → verification
+- Document all features in README.md

--- a/tests/fixtures/jules-basic/rules/file-pattern-rule.mdc
+++ b/tests/fixtures/jules-basic/rules/file-pattern-rule.mdc
@@ -1,0 +1,14 @@
+---
+description:
+globs:
+alwaysApply: false
+---
+---
+description: "File pattern rule for TypeScript files"
+type: "file-pattern"
+patterns: ["*.ts"]
+---
+
+- Use strict type checking
+- Prefer interfaces over types for public APIs
+- Use optional chaining and nullish coalescing when appropriate

--- a/tests/fixtures/jules-basic/rules/opt-in-rule.mdc
+++ b/tests/fixtures/jules-basic/rules/opt-in-rule.mdc
@@ -1,0 +1,9 @@
+---
+description:
+globs:
+alwaysApply: false
+---
+
+- Follow semantic versioning for releases
+- Use conventional commits for commit messages
+- Run tests before pushing changes

--- a/tests/fixtures/jules-no-markers/aicm.json
+++ b/tests/fixtures/jules-no-markers/aicm.json
@@ -1,0 +1,4 @@
+{
+  "rulesDir": "./rules",
+  "targets": ["jules"]
+}

--- a/tests/fixtures/jules-no-markers/rules/no-marker-rule.mdc
+++ b/tests/fixtures/jules-no-markers/rules/no-marker-rule.mdc
@@ -1,0 +1,9 @@
+---
+description:
+globs:
+alwaysApply: false
+---
+
+# No Marker Rule
+
+This rule is used to test appending markers to an existing file without markers.


### PR DESCRIPTION
## Summary

  - Add support for the "jules" target which generates AGENTS.md files in the same format as the codex target
  - This allows users to use aicm with Jules AI assistant by specifying `"jules"` in their targets array
  - Jules target behaves identically to codex target - both use `.aicm` directory and `AGENTS.md` file

  ## Changes Made

  - Add "jules" to `SUPPORTED_TARGETS` array in `src/utils/config.ts`
  - Configure jules target to use `.aicm` directory and `AGENTS.md` file in `src/commands/install.ts`
  - Update documentation in `README.md` to mention jules target in both feature list and supported targets section
  - Add comprehensive test coverage with `tests/e2e/jules.test.ts` and corresponding fixtures
  - Update MCP server comments to include jules (like codex and windsurf, jules doesn't support MCP servers)

  ## Test Plan

  - [x] All existing tests continue to pass (66/66 tests passing)
  - [x] New jules integration tests verify AGENTS.md generation
  - [x] Tests verify jules target works with existing files and markers
  - [x] Lint and TypeScript build pass without errors
  - [x] Manual testing confirms jules target generates correct AGENTS.md files

  🤖 Generated with [Claude Code](https://claude.ai/code)