### PR TITLE
Join workspace commands at repository root for workspaces mode

### DIFF
--- a/tests/e2e/commands.test.ts
+++ b/tests/e2e/commands.test.ts
@@ -102,12 +102,48 @@ describe("command installation", () => {
       "Successfully installed 2 commands across 2 packages",
     );
 
+    const rootStructure = getDirectoryStructure(".cursor/commands");
+
+    expect(rootStructure).toEqual([
+      ".cursor/commands/aicm/",
+      ".cursor/commands/aicm/test-a.md",
+      ".cursor/commands/aicm/test-b.md",
+    ]);
+
+    expect(readTestFile(".cursor/commands/aicm/test-a.md")).toContain(
+      "Package A Command",
+    );
+    expect(readTestFile(".cursor/commands/aicm/test-b.md")).toContain(
+      "Package B Command",
+    );
+
     expect(readTestFile("package-a/.cursor/commands/aicm/test-a.md")).toContain(
       "Package A Command",
     );
     expect(readTestFile("package-b/.cursor/commands/aicm/test-b.md")).toContain(
       "Package B Command",
     );
-    expect(fileExists(".cursor/commands/aicm/test-a.md")).toBe(false);
+  });
+
+  test("dedupes preset commands when joining workspace commands", async () => {
+    await setupFromFixture("commands-workspace-preset");
+
+    const { stdout } = await runCommand("install --ci --verbose");
+
+    expect(stdout).toContain(
+      "Successfully installed 2 commands across 2 packages",
+    );
+
+    const structure = getDirectoryStructure(".cursor/commands");
+
+    expect(structure).toEqual([
+      ".cursor/commands/aicm/",
+      ".cursor/commands/aicm/test/",
+      ".cursor/commands/aicm/test/run-tests.md",
+    ]);
+
+    expect(readTestFile(".cursor/commands/aicm/test/run-tests.md")).toContain(
+      "Run shared workspace tests.",
+    );
   });
 });

--- a/tests/fixtures/commands-workspace-preset/aicm.json
+++ b/tests/fixtures/commands-workspace-preset/aicm.json
@@ -1,0 +1,4 @@
+{
+  "workspaces": true,
+  "targets": ["cursor"]
+}

--- a/tests/fixtures/commands-workspace-preset/package-a/aicm.json
+++ b/tests/fixtures/commands-workspace-preset/package-a/aicm.json
@@ -1,0 +1,4 @@
+{
+  "presets": ["../shared-preset"],
+  "targets": ["cursor"]
+}

--- a/tests/fixtures/commands-workspace-preset/package-b/aicm.json
+++ b/tests/fixtures/commands-workspace-preset/package-b/aicm.json
@@ -1,0 +1,4 @@
+{
+  "presets": ["../shared-preset"],
+  "targets": ["cursor"]
+}

--- a/tests/fixtures/commands-workspace-preset/package.json
+++ b/tests/fixtures/commands-workspace-preset/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "commands-workspace-preset",
+  "private": true,
+  "workspaces": [
+    "package-a",
+    "package-b"
+  ]
+}

--- a/tests/fixtures/commands-workspace-preset/shared-preset/aicm.json
+++ b/tests/fixtures/commands-workspace-preset/shared-preset/aicm.json
@@ -1,0 +1,4 @@
+{
+  "commandsDir": "./commands",
+  "skipInstall": true
+}

--- a/tests/fixtures/commands-workspace-preset/shared-preset/commands/test/run-tests.md
+++ b/tests/fixtures/commands-workspace-preset/shared-preset/commands/test/run-tests.md
@@ -1,0 +1,3 @@
+# Run Workspace Tests
+
+Run shared workspace tests.


### PR DESCRIPTION
## Summary
- aggregate commands from workspace packages and install them at the repository root when Cursor is targeted
- dedupe preset-provided commands across packages before writing and reuse existing collision warnings
- extend command workspace tests with root assertions and add a new preset workspace fixture to cover the new behaviour

------
https://chatgpt.com/codex/tasks/task_e_68f776bc7fac832586a21dd85b02e3e2