### PR TITLE
Extend path rewriting to all relative path formats in commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ Use the schema defined in [Schema Template](../rules/schema.json) to generate th
 
 When installed, `aicm` will automatically rewrite the link to point to the correct location of `schema.json` in the target environment (e.g., `../../rules/aicm/schema.json` for Cursor).
 
+> **Note:** Path rewriting works for any relative path format in your commands - markdown links, inline code references, or bare paths - as long as they point to actual files in your `rulesDir`.
+
 ### Overrides
 
 You can disable or replace specific rules or commands provided by presets using the `overrides` field:

--- a/tests/e2e/commands.test.ts
+++ b/tests/e2e/commands.test.ts
@@ -158,7 +158,7 @@ describe("command installation", () => {
 
     const commandContent = readTestFile(commandPath);
 
-    // Links should preserve subdirectory structure like category-a/ and deep/nested/structure/
+    // Markdown links should be rewritten with subdirectory structure preserved
     expect(commandContent).toContain(
       "[First asset in subdirectory](../../rules/aicm/category-a/asset-one.mjs)",
     );
@@ -168,5 +168,24 @@ describe("command installation", () => {
     expect(commandContent).toContain(
       "[Deeply nested asset](../../rules/aicm/deep/nested/structure/config.json)",
     );
+
+    // Inline code references should be rewritten (filesystem-based detection)
+    expect(commandContent).toContain(
+      "`node ../../rules/aicm/category-a/asset-one.mjs`",
+    );
+    expect(commandContent).toContain(
+      "`../../rules/aicm/category-a/asset-two.mjs`",
+    );
+
+    // Bare path references should be rewritten
+    expect(commandContent).toContain(
+      "You can also run: ../../rules/aicm/deep/nested/structure/config.json",
+    );
+
+    // Code blocks should NOT be rewritten (contains example paths)
+    expect(commandContent).toContain("../rules/example/fake.js");
+
+    // Non-existent paths should NOT be rewritten
+    expect(commandContent).toContain("../rules/nonexistent/file.js");
   });
 });

--- a/tests/fixtures/commands-subdirectory-links/commands/example.md
+++ b/tests/fixtures/commands-subdirectory-links/commands/example.md
@@ -1,7 +1,30 @@
 # Example Command
 
-This command references:
+This command references assets in various formats:
+
+## Markdown Links
 
 - [First asset in subdirectory](../rules/category-a/asset-one.mjs)
 - [Second asset in subdirectory](../rules/category-a/asset-two.mjs)
 - [Deeply nested asset](../rules/deep/nested/structure/config.json)
+
+## Inline Code References
+
+Run the script: `node ../rules/category-a/asset-one.mjs`
+
+Execute: `../rules/category-a/asset-two.mjs`
+
+## Bare Path References
+
+You can also run: ../rules/deep/nested/structure/config.json
+
+## Code Block (should NOT be rewritten)
+
+```bash
+# This is an example and should not be rewritten
+node ../rules/example/fake.js
+```
+
+## Non-existent Path (should NOT be rewritten)
+
+This path doesn't exist: ../rules/nonexistent/file.js


### PR DESCRIPTION
Extends path rewriting to support all relative path formats (markdown links, inline code, bare paths) using filesystem-based detection. Only rewrites paths that point to actual files in rulesDir.