### PR TITLE
feat: copy auxiliary files referenced by commands in workspace mode

### DIFF
--- a/tests/fixtures/commands-workspace-aux-files/aicm.json
+++ b/tests/fixtures/commands-workspace-aux-files/aicm.json
@@ -1,0 +1,3 @@
+{
+  "targets": ["cursor"]
+}

--- a/tests/fixtures/commands-workspace-aux-files/package-a/aicm.json
+++ b/tests/fixtures/commands-workspace-aux-files/package-a/aicm.json
@@ -1,0 +1,5 @@
+{
+  "commandsDir": "commands",
+  "rulesDir": "rules",
+  "targets": ["cursor"]
+}

--- a/tests/fixtures/commands-workspace-aux-files/package-a/commands/test.md
+++ b/tests/fixtures/commands-workspace-aux-files/package-a/commands/test.md
@@ -1,0 +1,17 @@
+# Test Command
+
+This command references various auxiliary files.
+
+## Manual Rule Reference
+
+See the manual rule: [Manual Rule](../rules/manual-rule.mdc)
+
+## Auto Rule Reference
+
+See the auto rule: [Auto Rule](../rules/auto-rule.mdc)
+
+## Helper Script
+
+Run the helper script: `node ../rules/helper.js`
+
+Or reference it directly: ../rules/helper.js

--- a/tests/fixtures/commands-workspace-aux-files/package-a/rules/auto-rule.mdc
+++ b/tests/fixtures/commands-workspace-aux-files/package-a/rules/auto-rule.mdc
@@ -1,0 +1,8 @@
+---
+alwaysApply: true
+---
+
+# Auto Rule
+
+This is an automatic rule that always applies.
+It should trigger a warning when referenced by a command.

--- a/tests/fixtures/commands-workspace-aux-files/package-a/rules/helper.js
+++ b/tests/fixtures/commands-workspace-aux-files/package-a/rules/helper.js
@@ -1,0 +1,2 @@
+// Helper script for testing auxiliary file copying
+console.log("Helper script executed");

--- a/tests/fixtures/commands-workspace-aux-files/package-a/rules/manual-rule.mdc
+++ b/tests/fixtures/commands-workspace-aux-files/package-a/rules/manual-rule.mdc
@@ -1,0 +1,4 @@
+# Manual Rule
+
+This is a manual rule with no frontmatter metadata.
+It should not trigger a warning when referenced by a command.

--- a/tests/fixtures/commands-workspace-aux-files/package.json
+++ b/tests/fixtures/commands-workspace-aux-files/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "workspace-root",
+  "private": true,
+  "workspaces": [
+    "package-a"
+  ]
+}


### PR DESCRIPTION
# Copy auxiliary files referenced by commands in workspace mode

## Problem
When installing commands in workspace mode, commands are installed at the monorepo root for IDE accessibility. However, these commands often reference auxiliary files (helper scripts, config files, etc.) using relative paths like `../rules/file.js`. These references break because:

1. Commands are installed at `.cursor/commands/aicm/` (root level)
2. Auxiliary files exist in nested packages at `packages/*/rules/`
3. Relative paths like `../rules/file.js` don't work from the root location

## Solution
Extract and copy auxiliary files referenced by commands to the root directory, ensuring commands work correctly when opened from the monorepo root.

### Key Changes
- **Added auxiliary file extraction**: `extractMdcReferences()` function finds .mdc files referenced by commands
- **Added rule type detection**: `isManualRule()` identifies manual vs automatic rules to warn about potential duplication
- **Added file processing**: `processMdcFilesForWorkspace()` handles copying and warning logic
- **Updated workspace installation**: Commands in workspace mode now copy referenced .mdc files to root
- **Added comprehensive tests**: E2E test validates file copying, warning generation, and link rewriting

### Behavior
- **All referenced .mdc files** are copied to `.cursor/rules/aicm/` at root
- **Warnings** are issued for non-manual .mdc files (automatic/auto-attached/agent-requested) to prevent double inclusion
- **Link rewriting** updates command references to point to copied files
- **Manual rules** (.mdc files without special metadata) are copied silently
- **Asset integration** reuses existing asset infrastructure for consistent behavior

### Why This Matters
In workspace mode, users open commands from the monorepo root. Without this fix, commands would fail when referencing auxiliary files from nested packages. This ensures a seamless experience when using AICM in monorepos.