### PR TITLE
Fix critical bug in preset asset path rewriting

### DIFF
--- a/tests/fixtures/preset-commands-assets/my-preset/assets/schema.json
+++ b/tests/fixtures/preset-commands-assets/my-preset/assets/schema.json
@@ -1,0 +1,7 @@
+{
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "version": { "type": "string" }
+  }
+}

--- a/tests/fixtures/preset-commands-assets/my-preset/commands/setup.md
+++ b/tests/fixtures/preset-commands-assets/my-preset/commands/setup.md
@@ -1,11 +1,11 @@
 # Setup Command
 
-This command uses configuration from the preset.
+This command uses assets from the preset.
 
-## Configuration
+## Schema
 
-The configuration file is located at [config.json](../rules/config.json).
+The schema file is located at [schema.json](../assets/schema.json).
 
-You can also reference it inline: `../rules/config.json`
+You can also reference it inline: `../assets/schema.json`
 
-Or in a sentence: Check the file at ../rules/config.json for more details.
+Or in a sentence: Check the file at ../assets/schema.json for more details.

--- a/tests/fixtures/preset-commands-assets/my-preset/rules/preset-rule.mdc
+++ b/tests/fixtures/preset-commands-assets/my-preset/rules/preset-rule.mdc
@@ -1,3 +1,3 @@
 # Preset Rule
 
-This is a rule from the preset.
+This is a rule from the preset that references [schema.json](../assets/schema.json).


### PR DESCRIPTION
# Fix critical bug in preset asset path rewriting

## Summary

Fixed a critical bug where assets from presets were not being referenced correctly in installed commands and rules. When presets contained assets, the relative paths to those assets were being rewritten incorrectly, causing broken links because the preset namespace wasn't being included in the asset paths.

## Problem

When assets from presets are installed, they get namespaced (e.g., `.cursor/assets/aicm/my-preset/schema.json`), but the `rewriteAssetReferences` function was blindly replacing `../assets/` with `../../assets/aicm/` without accounting for:

1. **Preset namespace**: Assets from presets include the namespace in their installation path
2. **Installation depth**: Files from presets are installed in deeper directory structures
3. **Different target behaviors**: Cursor vs Windsurf/Codex/Claude have different asset installation patterns

This resulted in broken asset references like `../../assets/aicm/schema.json` instead of the correct `../../assets/aicm/my-preset/schema.json`.

## Solution

Refactored the `rewriteAssetReferences` function to:

- Accept `presetName` and `fileInstallDepth` parameters to calculate correct relative paths
- Include preset namespace in rewritten asset paths for preset files
- Calculate proper relative path depth based on file installation location
- Handle different targets appropriately (Cursor uses `.cursor/assets/aicm/`, others use `.aicm/`)