### PR TITLE
clean command doesn't need to load presest

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,6 @@
 import { install as installInternal } from "./commands/install";
 import { InstallOptions, InstallResult } from "./commands/install";
+import { checkWorkspacesEnabled as checkWorkspacesEnabledInternal } from "./utils/config";
 
 /**
  * Install AICM rules based on configuration
@@ -10,6 +11,15 @@ export async function install(
   options: InstallOptions = {},
 ): Promise<InstallResult> {
   return installInternal(options);
+}
+
+/**
+ * Check if workspaces mode is enabled without loading all rules/presets
+ * @param cwd Current working directory (optional, defaults to process.cwd())
+ * @returns True if workspaces mode is enabled
+ */
+export async function checkWorkspacesEnabled(cwd?: string): Promise<boolean> {
+  return checkWorkspacesEnabledInternal(cwd);
 }
 
 export type { InstallOptions, InstallResult } from "./commands/install";

--- a/src/commands/clean.ts
+++ b/src/commands/clean.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import fs from "fs-extra";
 import path from "node:path";
-import { loadConfig, detectWorkspacesFromPackageJson } from "../utils/config";
+import { checkWorkspacesEnabled } from "../utils/config";
 import { withWorkingDirectory } from "../utils/working-directory";
 import { removeRulesBlock } from "../utils/rules-file-writer";
 import { discoverPackagesWithAicm } from "../utils/workspace-discovery";
@@ -305,9 +305,7 @@ export async function clean(options: CleanOptions = {}): Promise<CleanResult> {
   const cwd = options.cwd || process.cwd();
   const verbose = options.verbose || false;
 
-  const shouldUseWorkspaces =
-    (await loadConfig(cwd))?.config.workspaces ||
-    detectWorkspacesFromPackageJson(cwd);
+  const shouldUseWorkspaces = await checkWorkspacesEnabled(cwd);
 
   if (shouldUseWorkspaces) {
     return cleanWorkspaces(cwd, verbose);

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -607,6 +607,26 @@ export async function loadConfigFile(
   }
 }
 
+/**
+ * Check if workspaces mode is enabled without loading all rules/presets
+ * This is useful for commands that only need to know the workspace setting
+ */
+export async function checkWorkspacesEnabled(cwd?: string): Promise<boolean> {
+  const workingDir = cwd || process.cwd();
+
+  const configResult = await loadConfigFile(workingDir);
+
+  if (!configResult?.config) {
+    return detectWorkspacesFromPackageJson(workingDir);
+  }
+
+  return resolveWorkspaces(
+    configResult.config,
+    configResult.filepath,
+    workingDir,
+  );
+}
+
 export async function loadConfig(cwd?: string): Promise<ResolvedConfig | null> {
   const workingDir = cwd || process.cwd();
 


### PR DESCRIPTION
Fixed a bug where clean command required loading presets