### PR TITLE
Add GitHub Actions workflow for automated npm publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - run: npm ci
+      - run: npm test
+      - run: npm publish --provenance --access public

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint": "eslint",
     "prepare": "husky install && npx ts-node src/bin/aicm.ts install",
     "version": "auto-changelog -p && git add CHANGELOG.md",
-    "release": "np --no-tests"
+    "release": "np --no-tests --no-publish"
   },
   "keywords": [
     "ai",


### PR DESCRIPTION
## Summary

- Add `publish.yml` GitHub Actions workflow that triggers on version tags (`v*.*.*`)
- Enable npm provenance for supply chain security and package authenticity
- Update release script to use `--no-publish` flag, delegating publishing to CI

## Why

This separates the release flow into two stages:
1. **Local (via `np`)**: Version bump, changelog generation, and git tag creation
2. **CI (via GitHub Actions)**: Automated npm publish with provenance support

This approach ensures consistent, secure publishing from CI with npm provenance enabled for supply chain security.