### PR TITLE
Update publish workflow to use pnpm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,11 +15,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.18.3
+
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
+          cache: pnpm
 
-      - run: npm ci
-      - run: npm test
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test
       - run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary

- Add pnpm setup to the publish workflow for consistent dependency management
- Enable pnpm caching for faster CI runs
- Use pnpm for installing dependencies and running tests
- Keep npm for publishing to the registry (npm publish works with pnpm-installed packages)

## Why

The project uses pnpm as its package manager, but the publish workflow was still using npm for all operations. This aligns the publish workflow with the CI workflow which already uses pnpm.