### PR TITLE
Fix npm trusted publishing and remove redundant test step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
           cache: pnpm
 


### PR DESCRIPTION
## Summary

- Remove `pnpm test` step from publish workflow (tests already run on PR merge)
- Upgrade to Node.js 24 for npm trusted publishing OIDC support

## Why

Publishing was failing with "Access token expired" / 404 errors despite correct trusted publisher configuration. The root cause is that npm trusted publishing with OIDC requires npm v11.5.1+, which ships with Node.js 24. Node 22 includes npm v10 which doesn't properly handle the OIDC token exchange for authentication.

Reference: https://medium.com/@kenricktan11/npm-trusted-publishers-the-weird-404-error-and-the-node-js-24-fix-a9f1d717a5dd