### PR TITLE
Fix npm provenance verification by adding repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
   ],
   "author": "Ran Yitzhaki <ranyitz@gmail.com>",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ranyitz/aicm"
+  },
   "dependencies": {
     "arg": "^5.0.2",
     "chalk": "^4.1.2",


### PR DESCRIPTION
## Summary

- Add `repository` field to `package.json` with the GitHub URL

## Why

npm's sigstore provenance verification was failing during publish from GitHub Actions with error:

> Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/ranyitz/aicm" from provenance

The `repository.url` in package.json must match the GitHub repository for provenance verification to pass.