### PR TITLE
Fix publish workflow to build before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,4 +26,5 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
+      - run: pnpm build
       - run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary

- Add missing `pnpm build` step to the publish workflow
- Ensures TypeScript is compiled before `npm publish` runs

## Why

The publish workflow was attempting to publish the package without first building it, which would result in missing compiled JavaScript files in the published package.