### PR TITLE
Fix package.json bin path and repository URL format

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/api.js",
   "types": "dist/api.d.ts",
   "bin": {
-    "aicm": "./dist/bin/aicm.js"
+    "aicm": "dist/bin/aicm.js"
   },
   "files": [
     "dist",
@@ -39,7 +39,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ranyitz/aicm"
+    "url": "git+https://github.com/ranyitz/aicm.git"
   },
   "dependencies": {
     "arg": "^5.0.2",


### PR DESCRIPTION
## Summary

- Remove leading `./` from bin path for consistency (`./dist/bin/aicm.js` → `dist/bin/aicm.js`)
- Update repository URL to follow npm's standard format (`git+https://...git`)

## Why

These are minor fixes to align package.json with npm conventions and improve consistency. The repository URL format follows npm's recommended pattern for proper linking on the npm registry.