### PR TITLE
Add new_latest parameter to unpublish workflow

### DIFF
--- a/.github/workflows/unpublish.yml
+++ b/.github/workflows/unpublish.yml
@@ -7,6 +7,10 @@ on:
         description: "Version to unpublish (e.g., 0.20.5)"
         required: true
         type: string
+      new_latest:
+        description: "New version to tag as latest (leave empty to skip)"
+        required: false
+        type: string
 
 jobs:
   unpublish:
@@ -17,6 +21,13 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
-      - run: npm unpublish aicm@${{ inputs.version }}
+      - name: Set new latest tag
+        if: ${{ inputs.new_latest != '' }}
+        run: npm dist-tag add aicm@${{ inputs.new_latest }} latest
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Unpublish version
+        run: npm unpublish aicm@${{ inputs.version }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Add optional `new_latest` parameter to set a new latest tag before unpublishing
- Set the latest tag before unpublishing (so the version still exists when tagging)

## Why

When unpublishing the current `latest` version, npm doesn't automatically reassign the tag. This allows setting a new latest in the same workflow run.